### PR TITLE
Fix bug in Orbit causing compilation with ifort to fail

### DIFF
--- a/classes/Orbit_class.f90
+++ b/classes/Orbit_class.f90
@@ -6498,7 +6498,8 @@ CONTAINS
 
     TYPE (CartesianCoordinates) :: observer_
     REAL(bp), DIMENSION(3)      :: asteroid2sun, asteroid2observer
-
+    REAL(bp), DIMENSION(6)      :: asteroidelems
+    
     IF (.NOT. this%is_initialized) THEN
        error = .TRUE.
        CALL errorMessage("Orbit / getSolarElongation", &
@@ -6514,7 +6515,9 @@ CONTAINS
     END IF
 
     ! Ecliptic position vector from asteroid to the Sun:
-    asteroid2sun = -1.0_bp*getElements(this, "cartesian", "ecliptic")
+    asteroidelems = -1.0_bp*getElements(this, "cartesian", "ecliptic")
+    asteroid2sun = asteroidelems(1:3)
+    
     IF (error) THEN
        CALL errorMessage("Orbit / getSolarElongation", &
             "TRACE BACK (5)", 1)


### PR DESCRIPTION
Currently the getSolarElongation_Orb function tries to set values for 6 elements of a 3-element array. This is a bug, and breaks compilation with the Intel compiler. This commit fixes the issue, and thus compilation with ifort works again.