### PR TITLE
Add 2body ephemeris generation option to pyoorb.f90

### DIFF
--- a/python/oorb_2b.conf
+++ b/python/oorb_2b.conf
@@ -1,0 +1,438 @@
+#====================================================================#
+#                                                                    #
+# Copyright 2002-2014,2015                                           #
+# Mikael Granvik, Jenni Virtanen, Karri Muinonen, Teemu Laakso,      #
+# Dagmara Oszkiewicz                                                 #
+#                                                                    #
+# This file is part of OpenOrb.                                      #
+#                                                                    #
+# OpenOrb is free software: you can redistribute it and/or modify it #
+# under the terms of the GNU General Public License as published by  #
+# the Free Software Foundation, either version 3 of the License, or  #
+# (at your option) any later version.                                #
+#                                                                    #
+# OpenOrb is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of         #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  #
+# General Public License for more details.                           #
+#                                                                    #
+# You should have received a copy of the GNU General Public License  #
+# along with OpenOrb. If not, see <http://www.gnu.org/licenses/>.    #
+#                                                                    #
+#====================================================================#
+#
+# Option file for OpenOrb executable 'oorb'
+#
+# The order in which the keywords are given can be arbitrary, 
+# lines starting with "#" are ignored.
+#
+# Author:  MG
+# Version: 2015-12-04
+
+
+# GENERAL SETTINGS
+
+# Verbose level for informative messages (0=nothing and 5=maximum, default=1)
+verbose.info:   1
+
+# Verbose level for error messages (0=nothing and 5=maximum, default=1)
+verbose.error:   1
+
+# Name of binary file containing JPL's planetary ephemerides,
+# typically deXXX.dat, where XXX is, e.g., 405, 406, 430, 431, or
+# IMCCE's INPOP planetary ephemerides that can be read with code
+# adhering to the testeph.f algorithm such as the little-endian TDB
+# version of INPOP10b.
+planetary_ephemeris_fname: de430.dat
+
+
+# INPUT
+
+# Standard deviation of RA (in asec). If *.mpc[23] files (that may
+# contain information on the observational noise) are the input data,
+# this parameter may be commented out. Otherwise it will override any
+# noise estimates included in the file.
+stdev.ra: 1.0
+
+# Standard deviation of Dec (in asec). If *.mpc[23] files (that may
+# contain information on the observational noise) are the input data,
+# this parameter may be commented out. Otherwise it will override any
+# noise estimates included in the file.
+stdev.dec: 1.0
+
+
+# OUTPUT
+
+# Element type to be used in the resulting orbital element file
+# [ keplerian | cartesian | cometary ]  
+element_type_out: cometary
+
+# Write O-C residuals to file (T=yes/F=no)
+write.residuals: F
+
+# Automatic plot generation (T=yes/F=no)
+plot.results: T
+
+# Automatic plot opening for each object (T=yes/F=no)
+plot.open: F
+
+# Format of output observation file
+# [ mpc | des ]
+observation.format.out: des
+
+# Format of output orbit file
+# [ orb | des ]
+orbit.format.out: des
+
+
+# GENERAL INVERSION PARAMETERS
+
+# Orbital element type used during computations
+# [ keplerian | cartesian | cometary ]  
+element_type_comp: cartesian
+
+# Computation epoch TT (YYYY/MM/DD.DDDDD or JD or MJD) 
+# If left unspecified and doing inversion, the midnight closest to 
+# the observational mid-epoch will be used. 
+#epoch.cal:  2008/10/6.1146
+#epoch.jd:      2453800.5
+#epoch.mjd:       53800.0
+
+# Toggle outlier rejection
+outlier_rejection: T
+
+# Outlier criterion (sigma multiplier)
+outlier.multiplier: 4.0
+
+# Sigma multiplier for generation of deviates
+generation.multiplier:    4.0
+
+# Defines whether the generated deviates are drawn from a Gaussian
+# distribution (T) or a uniform distribution (F).
+generation.gaussian_deviates: F
+
+# Sigma multiplier for acceptance windows
+accwin.multiplier:      4.0
+
+
+# PROPAGATION PARAMETERS
+
+# Dynamical model
+# [ 2-body | n-body ]
+dynamical_model:      2-body
+
+# Perturbing bodies to be taken into account in n-body propagation
+# [ T | F ]
+perturber.Mercury: T
+perturber.Venus:   T
+perturber.Earth:   T
+perturber.Moon:    T
+perturber.Mars:    T
+perturber.Jupiter: T
+perturber.Saturn:  T
+perturber.Uranus:  T
+perturber.Neptune: T
+perturber.Pluto:   T
+
+# Integrator (only used if dynamical model is different from
+# 2-body).
+# [ bulirsch-stoer ]
+integrator: bulirsch-stoer
+
+# Integrator step length (in days)
+integration_step:      1.0
+
+# Relativistic corrections
+relativity: T
+
+# Dynamical model of the initial orbit
+# [ 2-body | n-body ]
+dynamical_model_init:      n-body
+
+# Integrator of the initial orbit (only used if dynamical model is
+# different from 2-body).
+# [ bulirsch-stoer ] 
+integrator_init: bulirsch-stoer
+
+# Integrator step length of the initial orbit (in days)
+integration_step_init:       1.0
+
+# Maximum number of massless particles integrated simultaneously
+simint: 1
+
+
+# STATISTICAL PARAMETERS
+
+# Use the dchi2 criterion when deciding which trial orbits are
+# rejected (default on).
+dchi2_rejection: T
+
+# Maximum chi2 difference between best-fit orbit and accepted sample
+# orbits (20.1 = 99.73% of the total probability mass, 30 = XX % of
+# the total probability mass).
+dchi2.max: 30
+
+# Regularize the PDF using Jeffreys' prior (default off).
+reg.pdf:         F
+
+# Read observation mask from observation file
+obs.mask:        F
+
+# Assumed minimum value for chi2 at start of inversion ('-1' equals
+# setting the minimum to 2 * number of observations)
+chi2_min.init:  -1
+
+
+# BAYESIAN (INFORMATIVE) A PRIORI PARAMETERS
+
+# Lower limit for semimajor axis in AU (default: r_Sun = 0.00465424 AU)
+apriori.a.min : 0.00465424
+
+# Upper limit for semimajor axis in AU
+apriori.a.max : 1000.0
+
+# Lower limit for perihelion distance in AU
+#apriori.q.min : 0.00465424
+
+# Upper limit for perihelion distance in AU
+#apriori.q.max : 1.3 
+
+# Lower limit for aphelion distance in AU
+#apriori.Q.min : 
+
+# Upper limit for aphelion distance in AU
+#apriori.Q.max : 1.3 
+
+# Lower limit for rho in AU (default: 10*r_Earth = 0.000425641 AU)
+#apriori.rho.min : 0.000425641 
+
+# Upper limit for rho in AU (default: not defined)
+#apriori.rho.max :
+
+
+# MC / MCMC STATISTICAL ORBITAL RANGING
+
+# Method for solving the two-point boundary-value problem
+# [ continued fraction | p-iteration | n-body amoeba ]
+sor.two_point_method: continued fraction
+
+# Type of ranging (1=basic, 2=automatic, 3=stepwise)
+sor.type:           2
+
+# Number of requested sample orbits
+sor.norb:           2000
+
+# Maximum number of trial orbits
+sor.ntrial:         1000000
+
+# Method for solving the two-point boundary-value problem during
+# the preliminary steps of stepwise Ranging
+# [ continued fraction | p-iteration | n-body amoeba ]
+sor.two_point_method_sw: continued fraction
+
+# Number of requested sample orbits for the preliminary steps of
+# stepwise ranging 
+sor.norb.sw:        500
+
+# Maximum number of trial orbits for the preliminary steps of
+# stepwise ranging
+sor.ntrial.sw:      200000
+
+# Maximum number of iterations in automatic/stepwise Ranging
+sor.niter:          3
+
+# Lower topocentric range bound corresponding to the first date 
+# (observer -> target) [AU]
+sor.rho11.init:     0.0
+
+# Upper topocentric range bound corresponding to the first date 
+# (observer -> target) [AU]
+sor.rho12.init:     100.0
+
+# Lower topocentric range bound of the second date relative to the 
+# generated range of the first date [AU]
+#sor.rho21.init:    -0.1
+
+# Upper topocentric range bound of the second date relative to the 
+# generated range of the first date [AU]
+#sor.rho22.init:     0.1
+
+# Offset for generation windows RA1, Dec1, RA2, Dec2 [asec]
+sor.genwin.offset:    0.0 0.0 0.0 0.0
+
+# Toggle use of random observation pair. Default is off, that is, use
+# fixed pair (cronologically first and last).  
+#sor.ran.obs:
+
+# Bounds to be iterated in automatical versions 
+# (rho1_lo, rho1_hi, rho2_lo, rho2_hi) 
+sor.iterate_bounds: T T T T
+
+
+# VOLUME OF VARIATION
+
+# Type of method (1=basic, 2=automatic)
+vov.type:           2
+
+# Number of requested sample orbits
+vov.norb:           1000
+
+# Maximum number of trial orbits
+vov.ntrial:         1000000
+
+# Number of requested sample orbits during iteration phase of
+# automatic VoV.
+vov.norb_iter:      1000
+
+# Maximum number of trial orbits during iteration phase of automatic
+# VoV.
+vov.ntrial_iter:    1000000
+
+# Maximum number of iterations during automatic VoV
+vov.niter:          5
+
+# Mapping element (T indicates mapping element, the five other
+# elements should be marked with F)
+vov.mapping_mask: T F F F F F
+
+# Number of mapping points
+vov.nmap:           101
+
+# Scaling factors (initial scaling factors for automatic VoV)
+vov.scaling.lo:  5.0 5.0 5.0 2.0 2.0 2.0
+vov.scaling.hi:  5.0 5.0 5.0 2.0 2.0 2.0
+
+
+# VIRTUAL OBSERVATION MCMC
+
+# Type of method (1=basic, 2=automatic)
+vomcmc.type:           1
+
+# Number of requested sample orbits
+vomcmc.norb:           200
+
+# Maximum number of trial orbits
+vomcmc.ntrial:         1000000
+
+# Number of requested sample orbits during iteration phase of
+# automatic VOMCMC.
+vomcmc.norb_iter:      1000
+
+# Maximum number of trial orbits during iteration phase of automatic
+# VOMCMC.
+vomcmc.ntrial_iter:    1000000
+
+# Maximum number of iterations during automatic VOMCMC.
+vomcmc.niter:          5
+
+# Mapping element (T indicates mapping element, the five other
+# elements should be marked with F)
+vomcmc.mapping_mask: T F F F F F
+
+# Number of mapping points
+vomcmc.nmap:           10
+
+# Scaling factors (initial scaling factors for automatic VOMCMC)
+vomcmc.scaling.lo:  2.0 2.0 2.0 2.0 2.0 2.0
+vomcmc.scaling.hi:  2.0 2.0 2.0 2.0 2.0 2.0
+
+
+# LEAST SQUARES
+
+# Correction factor for the iterative solution of the least-squares
+# problem (NOT used for the default [Levenberg-Marquardt] algorithm)
+# [0:1]
+ls.correction_factor:  0.2
+
+# Maximum acceptable reduced chi2 value for calling a differential
+# correction procedure successful (note that a failure to meet this
+# criteria may indicate that the assumption for the astrometric
+# uncertainty is too optimistic, ie, too small.)
+ls.rchi2.acceptable:  1.2
+
+# Maximum number of major iterations
+ls.niter_major.max:  20
+
+# Minimum number of major iterations
+ls.niter_major.min:  2
+
+# Number of iterations per scheme
+ls.niter_minor:  100
+
+# Elements to included in the correction process (indicated with
+# T). Fixed elements should be marked with F.
+ls.element_mask: T T T T T T
+
+
+# COVARIANCE SAMPLING
+
+# Generate a trial orbit by adding normally (T) or uniformly (F)
+# distributed offsets to the nominal orbit
+cos.gaussian: F
+
+# Size of volume to be sampled as the number of sigmas
+cos.nsigma: 8
+
+# Number of sample orbits requested
+cos.norb: 100
+
+# Maximum number of trial orbits
+cos.ntrial: 1000
+
+
+# SIMPLEX OPTIMIZATION
+
+# Reduced chi2 of the worst-fitting sample orbit (out of 7) required
+# for successfully ending the optimization 
+smplx.tol: 1.05
+
+# Maximum number of function evaluations
+smplx.niter: 1000
+
+# Tries to force all 7 orbits below smplx.tol if set to true (T) by
+# reinitializing when the orbits are above smplx.tol and the
+# optimization stalls due to too similar orbits. The optimization is
+# considered successful when the optimization stalls due to orbit
+# similarity if set to false (F).
+smplx.force: F
+
+# The treshold fractional range from highest to lowest chi2 which
+# either reinitializes the orbits or ends the optimization if very
+# similar chi2 values.
+smplx.similarity.tol: 0.001
+
+
+# OBSERVATION SAMPLING
+
+# Number of sample orbits requested
+os.norb: 200
+
+# Maximum number of generated observation sets
+os.ntrial: 10000
+
+# Type of MCMC sampling to be used. The options are (1) independence
+# sampling Metropolis-Hastings where the new observation sets are
+# always generated around the original observations and the acceptance
+# decision is made after comparison with the previous accepted orbit,
+# and (2) random-walk Metropolis-Hastings where the new observations
+# are generated around the observations generated for the previous
+# accepted orbit and the acceptance decision is made after comparison
+# with the previous accepted orbit.
+os.sampling_type: 1
+
+
+# PHYSICAL PARAMETERS
+
+# Toggle estimation of H(alpha=0) magnitude. Turning on this option
+# requires that the astrometry data file contain useful magnitude
+# information. This generally means it has to have at least three
+# values.
+# [ T | F ] 
+pp.H_estimation: T
+
+# Use given fixed slope parameter G when estimating H if specified 
+pp.G : 0.15
+
+# Use given fixed uncertainty for the slope parameter G when
+# estimating uncertainty for H if specified
+pp.G_unc : 0.10

--- a/python/oorb_nb.conf
+++ b/python/oorb_nb.conf
@@ -1,0 +1,438 @@
+#====================================================================#
+#                                                                    #
+# Copyright 2002-2014,2015                                           #
+# Mikael Granvik, Jenni Virtanen, Karri Muinonen, Teemu Laakso,      #
+# Dagmara Oszkiewicz                                                 #
+#                                                                    #
+# This file is part of OpenOrb.                                      #
+#                                                                    #
+# OpenOrb is free software: you can redistribute it and/or modify it #
+# under the terms of the GNU General Public License as published by  #
+# the Free Software Foundation, either version 3 of the License, or  #
+# (at your option) any later version.                                #
+#                                                                    #
+# OpenOrb is distributed in the hope that it will be useful, but     #
+# WITHOUT ANY WARRANTY; without even the implied warranty of         #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  #
+# General Public License for more details.                           #
+#                                                                    #
+# You should have received a copy of the GNU General Public License  #
+# along with OpenOrb. If not, see <http://www.gnu.org/licenses/>.    #
+#                                                                    #
+#====================================================================#
+#
+# Option file for OpenOrb executable 'oorb'
+#
+# The order in which the keywords are given can be arbitrary, 
+# lines starting with "#" are ignored.
+#
+# Author:  MG
+# Version: 2015-12-04
+
+
+# GENERAL SETTINGS
+
+# Verbose level for informative messages (0=nothing and 5=maximum, default=1)
+verbose.info:   1
+
+# Verbose level for error messages (0=nothing and 5=maximum, default=1)
+verbose.error:   1
+
+# Name of binary file containing JPL's planetary ephemerides,
+# typically deXXX.dat, where XXX is, e.g., 405, 406, 430, 431, or
+# IMCCE's INPOP planetary ephemerides that can be read with code
+# adhering to the testeph.f algorithm such as the little-endian TDB
+# version of INPOP10b.
+planetary_ephemeris_fname: de430.dat
+
+
+# INPUT
+
+# Standard deviation of RA (in asec). If *.mpc[23] files (that may
+# contain information on the observational noise) are the input data,
+# this parameter may be commented out. Otherwise it will override any
+# noise estimates included in the file.
+stdev.ra: 1.0
+
+# Standard deviation of Dec (in asec). If *.mpc[23] files (that may
+# contain information on the observational noise) are the input data,
+# this parameter may be commented out. Otherwise it will override any
+# noise estimates included in the file.
+stdev.dec: 1.0
+
+
+# OUTPUT
+
+# Element type to be used in the resulting orbital element file
+# [ keplerian | cartesian | cometary ]  
+element_type_out: cometary
+
+# Write O-C residuals to file (T=yes/F=no)
+write.residuals: F
+
+# Automatic plot generation (T=yes/F=no)
+plot.results: T
+
+# Automatic plot opening for each object (T=yes/F=no)
+plot.open: F
+
+# Format of output observation file
+# [ mpc | des ]
+observation.format.out: des
+
+# Format of output orbit file
+# [ orb | des ]
+orbit.format.out: des
+
+
+# GENERAL INVERSION PARAMETERS
+
+# Orbital element type used during computations
+# [ keplerian | cartesian | cometary ]  
+element_type_comp: cartesian
+
+# Computation epoch TT (YYYY/MM/DD.DDDDD or JD or MJD) 
+# If left unspecified and doing inversion, the midnight closest to 
+# the observational mid-epoch will be used. 
+#epoch.cal:  2008/10/6.1146
+#epoch.jd:      2453800.5
+#epoch.mjd:       53800.0
+
+# Toggle outlier rejection
+outlier_rejection: T
+
+# Outlier criterion (sigma multiplier)
+outlier.multiplier: 4.0
+
+# Sigma multiplier for generation of deviates
+generation.multiplier:    4.0
+
+# Defines whether the generated deviates are drawn from a Gaussian
+# distribution (T) or a uniform distribution (F).
+generation.gaussian_deviates: F
+
+# Sigma multiplier for acceptance windows
+accwin.multiplier:      4.0
+
+
+# PROPAGATION PARAMETERS
+
+# Dynamical model
+# [ 2-body | n-body ]
+dynamical_model:      n-body
+
+# Perturbing bodies to be taken into account in n-body propagation
+# [ T | F ]
+perturber.Mercury: T
+perturber.Venus:   T
+perturber.Earth:   T
+perturber.Moon:    T
+perturber.Mars:    T
+perturber.Jupiter: T
+perturber.Saturn:  T
+perturber.Uranus:  T
+perturber.Neptune: T
+perturber.Pluto:   T
+
+# Integrator (only used if dynamical model is different from
+# 2-body).
+# [ bulirsch-stoer ]
+integrator: bulirsch-stoer
+
+# Integrator step length (in days)
+integration_step:      1.0
+
+# Relativistic corrections
+relativity: T
+
+# Dynamical model of the initial orbit
+# [ 2-body | n-body ]
+dynamical_model_init:      n-body
+
+# Integrator of the initial orbit (only used if dynamical model is
+# different from 2-body).
+# [ bulirsch-stoer ] 
+integrator_init: bulirsch-stoer
+
+# Integrator step length of the initial orbit (in days)
+integration_step_init:       1.0
+
+# Maximum number of massless particles integrated simultaneously
+simint: 1
+
+
+# STATISTICAL PARAMETERS
+
+# Use the dchi2 criterion when deciding which trial orbits are
+# rejected (default on).
+dchi2_rejection: T
+
+# Maximum chi2 difference between best-fit orbit and accepted sample
+# orbits (20.1 = 99.73% of the total probability mass, 30 = XX % of
+# the total probability mass).
+dchi2.max: 30
+
+# Regularize the PDF using Jeffreys' prior (default off).
+reg.pdf:         F
+
+# Read observation mask from observation file
+obs.mask:        F
+
+# Assumed minimum value for chi2 at start of inversion ('-1' equals
+# setting the minimum to 2 * number of observations)
+chi2_min.init:  -1
+
+
+# BAYESIAN (INFORMATIVE) A PRIORI PARAMETERS
+
+# Lower limit for semimajor axis in AU (default: r_Sun = 0.00465424 AU)
+apriori.a.min : 0.00465424
+
+# Upper limit for semimajor axis in AU
+apriori.a.max : 1000.0
+
+# Lower limit for perihelion distance in AU
+#apriori.q.min : 0.00465424
+
+# Upper limit for perihelion distance in AU
+#apriori.q.max : 1.3 
+
+# Lower limit for aphelion distance in AU
+#apriori.Q.min : 
+
+# Upper limit for aphelion distance in AU
+#apriori.Q.max : 1.3 
+
+# Lower limit for rho in AU (default: 10*r_Earth = 0.000425641 AU)
+#apriori.rho.min : 0.000425641 
+
+# Upper limit for rho in AU (default: not defined)
+#apriori.rho.max :
+
+
+# MC / MCMC STATISTICAL ORBITAL RANGING
+
+# Method for solving the two-point boundary-value problem
+# [ continued fraction | p-iteration | n-body amoeba ]
+sor.two_point_method: continued fraction
+
+# Type of ranging (1=basic, 2=automatic, 3=stepwise)
+sor.type:           2
+
+# Number of requested sample orbits
+sor.norb:           2000
+
+# Maximum number of trial orbits
+sor.ntrial:         1000000
+
+# Method for solving the two-point boundary-value problem during
+# the preliminary steps of stepwise Ranging
+# [ continued fraction | p-iteration | n-body amoeba ]
+sor.two_point_method_sw: continued fraction
+
+# Number of requested sample orbits for the preliminary steps of
+# stepwise ranging 
+sor.norb.sw:        500
+
+# Maximum number of trial orbits for the preliminary steps of
+# stepwise ranging
+sor.ntrial.sw:      200000
+
+# Maximum number of iterations in automatic/stepwise Ranging
+sor.niter:          3
+
+# Lower topocentric range bound corresponding to the first date 
+# (observer -> target) [AU]
+sor.rho11.init:     0.0
+
+# Upper topocentric range bound corresponding to the first date 
+# (observer -> target) [AU]
+sor.rho12.init:     100.0
+
+# Lower topocentric range bound of the second date relative to the 
+# generated range of the first date [AU]
+#sor.rho21.init:    -0.1
+
+# Upper topocentric range bound of the second date relative to the 
+# generated range of the first date [AU]
+#sor.rho22.init:     0.1
+
+# Offset for generation windows RA1, Dec1, RA2, Dec2 [asec]
+sor.genwin.offset:    0.0 0.0 0.0 0.0
+
+# Toggle use of random observation pair. Default is off, that is, use
+# fixed pair (cronologically first and last).  
+#sor.ran.obs:
+
+# Bounds to be iterated in automatical versions 
+# (rho1_lo, rho1_hi, rho2_lo, rho2_hi) 
+sor.iterate_bounds: T T T T
+
+
+# VOLUME OF VARIATION
+
+# Type of method (1=basic, 2=automatic)
+vov.type:           2
+
+# Number of requested sample orbits
+vov.norb:           1000
+
+# Maximum number of trial orbits
+vov.ntrial:         1000000
+
+# Number of requested sample orbits during iteration phase of
+# automatic VoV.
+vov.norb_iter:      1000
+
+# Maximum number of trial orbits during iteration phase of automatic
+# VoV.
+vov.ntrial_iter:    1000000
+
+# Maximum number of iterations during automatic VoV
+vov.niter:          5
+
+# Mapping element (T indicates mapping element, the five other
+# elements should be marked with F)
+vov.mapping_mask: T F F F F F
+
+# Number of mapping points
+vov.nmap:           101
+
+# Scaling factors (initial scaling factors for automatic VoV)
+vov.scaling.lo:  5.0 5.0 5.0 2.0 2.0 2.0
+vov.scaling.hi:  5.0 5.0 5.0 2.0 2.0 2.0
+
+
+# VIRTUAL OBSERVATION MCMC
+
+# Type of method (1=basic, 2=automatic)
+vomcmc.type:           1
+
+# Number of requested sample orbits
+vomcmc.norb:           200
+
+# Maximum number of trial orbits
+vomcmc.ntrial:         1000000
+
+# Number of requested sample orbits during iteration phase of
+# automatic VOMCMC.
+vomcmc.norb_iter:      1000
+
+# Maximum number of trial orbits during iteration phase of automatic
+# VOMCMC.
+vomcmc.ntrial_iter:    1000000
+
+# Maximum number of iterations during automatic VOMCMC.
+vomcmc.niter:          5
+
+# Mapping element (T indicates mapping element, the five other
+# elements should be marked with F)
+vomcmc.mapping_mask: T F F F F F
+
+# Number of mapping points
+vomcmc.nmap:           10
+
+# Scaling factors (initial scaling factors for automatic VOMCMC)
+vomcmc.scaling.lo:  2.0 2.0 2.0 2.0 2.0 2.0
+vomcmc.scaling.hi:  2.0 2.0 2.0 2.0 2.0 2.0
+
+
+# LEAST SQUARES
+
+# Correction factor for the iterative solution of the least-squares
+# problem (NOT used for the default [Levenberg-Marquardt] algorithm)
+# [0:1]
+ls.correction_factor:  0.2
+
+# Maximum acceptable reduced chi2 value for calling a differential
+# correction procedure successful (note that a failure to meet this
+# criteria may indicate that the assumption for the astrometric
+# uncertainty is too optimistic, ie, too small.)
+ls.rchi2.acceptable:  1.2
+
+# Maximum number of major iterations
+ls.niter_major.max:  20
+
+# Minimum number of major iterations
+ls.niter_major.min:  2
+
+# Number of iterations per scheme
+ls.niter_minor:  100
+
+# Elements to included in the correction process (indicated with
+# T). Fixed elements should be marked with F.
+ls.element_mask: T T T T T T
+
+
+# COVARIANCE SAMPLING
+
+# Generate a trial orbit by adding normally (T) or uniformly (F)
+# distributed offsets to the nominal orbit
+cos.gaussian: F
+
+# Size of volume to be sampled as the number of sigmas
+cos.nsigma: 8
+
+# Number of sample orbits requested
+cos.norb: 100
+
+# Maximum number of trial orbits
+cos.ntrial: 1000
+
+
+# SIMPLEX OPTIMIZATION
+
+# Reduced chi2 of the worst-fitting sample orbit (out of 7) required
+# for successfully ending the optimization 
+smplx.tol: 1.05
+
+# Maximum number of function evaluations
+smplx.niter: 1000
+
+# Tries to force all 7 orbits below smplx.tol if set to true (T) by
+# reinitializing when the orbits are above smplx.tol and the
+# optimization stalls due to too similar orbits. The optimization is
+# considered successful when the optimization stalls due to orbit
+# similarity if set to false (F).
+smplx.force: F
+
+# The treshold fractional range from highest to lowest chi2 which
+# either reinitializes the orbits or ends the optimization if very
+# similar chi2 values.
+smplx.similarity.tol: 0.001
+
+
+# OBSERVATION SAMPLING
+
+# Number of sample orbits requested
+os.norb: 200
+
+# Maximum number of generated observation sets
+os.ntrial: 10000
+
+# Type of MCMC sampling to be used. The options are (1) independence
+# sampling Metropolis-Hastings where the new observation sets are
+# always generated around the original observations and the acceptance
+# decision is made after comparison with the previous accepted orbit,
+# and (2) random-walk Metropolis-Hastings where the new observations
+# are generated around the observations generated for the previous
+# accepted orbit and the acceptance decision is made after comparison
+# with the previous accepted orbit.
+os.sampling_type: 1
+
+
+# PHYSICAL PARAMETERS
+
+# Toggle estimation of H(alpha=0) magnitude. Turning on this option
+# requires that the astrometry data file contain useful magnitude
+# information. This generally means it has to have at least three
+# values.
+# [ T | F ] 
+pp.H_estimation: T
+
+# Use given fixed slope parameter G when estimating H if specified 
+pp.G : 0.15
+
+# Use given fixed uncertainty for the slope parameter G when
+# estimating uncertainty for H if specified
+pp.G_unc : 0.10

--- a/python/pyoorb.f90
+++ b/python/pyoorb.f90
@@ -689,6 +689,262 @@ CONTAINS
   END SUBROUTINE oorb_ephemeris
 
 
+  SUBROUTINE oorb_ephemeris_2b(in_norb, &
+       in_orbits,                    &
+       in_obscode,                   &
+       in_ndate,                     &
+       in_date_ephems,               &
+       out_ephems,                   &
+       error_code)
+
+    ! Input/Output variables.
+    INTEGER, INTENT(in)                                 :: in_norb
+    ! Input flattened orbit:
+    !  (track_id, elements(1:6), element_type_index, epoch, timescale, H, G)
+    REAL(8),DIMENSION(in_norb,12), INTENT(in)           :: in_orbits ! (1:norb,1:12)
+    ! Observatory code as defined by the Minor Planet Center
+    CHARACTER(len=*), INTENT(in)                        :: in_obscode
+    INTEGER, INTENT(in)                                 :: in_ndate
+    ! Ephemeris dates.
+    ! (mjd, timescale)
+    REAL(8), DIMENSION(in_ndate,2), INTENT(in)          :: in_date_ephems ! (1:ndate,1:2)
+    ! Output ephemeris
+    ! out_ephems = ((dist, ra, dec, mag, mjd, timescale, dra/dt, ddec/dt, phase, solar_elongation), )
+    REAL(8), DIMENSION(in_norb,in_ndate,10), INTENT(out) :: out_ephems ! (1:norb,1:ndate,1:8)
+    ! Output error code
+    INTEGER, INTENT(out)                                :: error_code
+
+    ! Internal variables.
+    TYPE (Orbit), DIMENSION(:,:), POINTER :: orb_lt_corr_arr
+    TYPE (Orbit), DIMENSION(1) :: orb_arr
+    TYPE (CartesianCoordinates), DIMENSION(:), ALLOCATABLE :: observers
+    TYPE (CartesianCoordinates) :: ccoord
+    TYPE (CartesianCoordinates) :: obsy_ccoord
+    TYPE (SphericalCoordinates), DIMENSION(:,:), POINTER :: ephemerides
+    TYPE (Time) :: t
+    REAL(8), DIMENSION(:,:), POINTER :: planeph
+    CHARACTER(len=INTEGRATOR_LEN) :: integrator
+    CHARACTER(len=6) :: dyn_model
+    REAL(8), DIMENSION(6) :: coordinates, &
+         elements
+    REAL(8), DIMENSION(3) :: obsy_obj, &
+         obsy_pos, &
+         geoc_obsy, &
+         obsy_sun, &
+         vec3, &
+         pos
+    REAL(8) :: cos_phase, &
+         ephemeris_r2, &
+         heliocentric_r2, &
+         integration_step, &
+         mjd, &
+         mjd_tt, &
+         observer_r2, &
+         phase, &
+         solar_elongation, &
+         vmag
+    INTEGER :: i, &
+         j
+    LOGICAL, DIMENSION(10) :: perturbers
+
+    ! Init
+    errstr = ""
+    error_code = 0
+    dyn_model = "2-body"
+    integrator = "bulirsch-stoer"
+    integration_step = 5.0_8
+    perturbers = .TRUE.
+    ALLOCATE(observers(SIZE(in_date_ephems,dim=1)))
+    DO i=1,SIZE(in_date_ephems,dim=1)
+       CALL NEW(t, in_date_ephems(i,1), timescales(NINT(in_date_ephems(i,2))))
+       IF (error) THEN
+          ! Error in creating a new Time object.
+          error_code = 35
+          RETURN
+       END IF
+       ! Compute heliocentric observatory coordinates
+       observers(i) = getObservatoryCCoord(obsies, in_obscode, t)
+       IF (error) THEN
+          ! Error in getObservatoryCCoord()
+          error_code = 36
+          RETURN
+       END IF
+       CALL rotateToEquatorial(observers(i))
+       CALL NULLIFY(t)
+    END DO
+
+    ! Loop over orbits:
+    DO i=1,SIZE(in_orbits,dim=1)
+
+       ! Get the element type from the input flattened orbit.
+       IF(NINT(in_orbits(i,8)) < 0 .OR.                                       &
+            NINT(in_orbits(i,8)) > SIZE(element_types)) THEN
+          ! Error: unsupported orbital elements.
+          error_code = 58
+          RETURN
+       END IF
+
+       ! Get each flattened orbit and create an Orbit instance.
+       elements(1:6) = in_orbits(i,2:7)
+       ! Create a Time instance.
+       CALL NEW(t, in_orbits(i,9), timescales(NINT(in_orbits(i,10))))
+       IF(error) THEN
+          ! Error in creating a Time instance.
+          error_code = 57
+          RETURN
+       END IF
+
+       ! Now create an instant of StochasticOrbit via an Orbit instance.
+       CALL NEW(orb_arr(1), &
+            elements(1:6), &
+            element_types(NINT(in_orbits(i,8))), &
+            "ecliptic", &
+            copy(t))
+       CALL NULLIFY(t)
+       CALL setParameters(orb_arr(1), &
+            dyn_model=dyn_model, &
+            perturbers=perturbers, &
+            integrator=integrator, &
+            integration_step=integration_step)
+       IF (error) THEN
+          error_code = 37
+          RETURN
+       END IF
+       ! Use cartesian equatorial coordinates:
+       CALL toCartesian(orb_arr(1), "equatorial")
+       !CALL toCometary(orb_arr(1))
+       IF (error) THEN
+          ! Error in setParameters()
+          error_code = 39
+          RETURN
+       END IF
+       ! Compute topocentric ephemerides
+       CALL getEphemerides(orb_arr, &
+            observers, &
+            ephemerides, &
+            this_lt_corr_arr=orb_lt_corr_arr)
+       IF (error) THEN
+          ! Error in getEphemerides()
+          error_code = 40
+          RETURN
+       END IF
+       CALL NULLIFY(orb_arr(1))
+
+       ! Now export the ephem_arr to a flat array.
+       DO j=1,SIZE(observers)
+
+          ! Make sure that the ephemeris is equatorial:
+          CALL rotateToEquatorial(ephemerides(1,j))
+          ! Extract RA & Dec
+          coordinates = getCoordinates(ephemerides(1,j))
+
+          ! Calculate apparent brightness
+          CALL NEW(ccoord, ephemerides(1,j))
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (50)',1)
+             STOP
+          END IF
+          CALL rotateToEquatorial(ccoord)
+          obsy_obj = getPosition(ccoord)
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (55)',1)
+             STOP
+          END IF
+          CALL NULLIFY(ccoord)
+          ephemeris_r2 = DOT_PRODUCT(obsy_obj,obsy_obj)
+          CALL toCartesian(orb_lt_corr_arr(1,j), frame='equatorial')
+          pos = getPosition(orb_lt_corr_arr(1,j))
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (60)',1)
+             STOP
+          END IF
+          heliocentric_r2 = DOT_PRODUCT(pos,pos)
+          obsy_pos = getPosition(observers(j))
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (65)',1)
+             STOP
+          END IF
+          geoc_obsy = obsy_pos - pos
+          observer_r2 = DOT_PRODUCT(obsy_pos,obsy_pos)
+          cos_phase = 0.5_bp * (heliocentric_r2 + ephemeris_r2 - &
+               observer_r2) / (SQRT(heliocentric_r2) * &
+               SQRT(ephemeris_r2))
+          phase = ACOS(cos_phase)
+
+
+
+          vmag = getApparentHGMagnitude(H=in_orbits(i,11), &
+               G=in_orbits(i,12), r=SQRT(heliocentric_r2), &
+               Delta=coordinates(1), phase_angle=phase)
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (70)',1)
+             STOP
+          END IF
+
+          ! ephem date
+          t = getTime(observers(j))
+          mjd = getMJD(t, timescales(NINT(in_date_ephems(j,2))))
+          mjd_tt = getMJD(t, "TT")
+          obsy_ccoord = getGeocentricObservatoryCCoord(obsies, in_obscode, t)
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (75)',1)
+             STOP
+          END IF
+          CALL rotateToEquatorial(obsy_ccoord)
+          geoc_obsy = getPosition(obsy_ccoord)
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (80)',1)
+             STOP
+          END IF
+
+          CALL NULLIFY(t)
+
+          planeph => JPL_ephemeris(mjd_tt, 3, 11, error)
+          IF (error) THEN
+             CALL errorMessage('oorb / ephemeris', &
+                  'TRACE BACK (85)',1)
+             STOP
+          END IF
+
+          geoc_obsy = getPosition(obsy_ccoord)
+          obsy_sun = -(planeph(1,1:3) + geoc_obsy)
+          vec3 = cross_product(obsy_obj,obsy_sun)
+          solar_elongation = ATAN2(SQRT(SUM(vec3**2)),DOT_PRODUCT(obsy_obj,obsy_sun))
+
+
+          ! Write the output ephem array.
+          out_ephems(i,j,1) = coordinates(1)                             ! distance
+          out_ephems(i,j,2) = coordinates(2)/rad_deg                     ! ra
+          out_ephems(i,j,3) = coordinates(3)/rad_deg                     ! dec
+          out_ephems(i,j,4) = vmag                                       ! mag
+          out_ephems(i,j,5) = mjd                                        ! ephem mjd
+          out_ephems(i,j,6) = NINT(in_date_ephems(j,2))                  ! ephem mjd timescale
+          out_ephems(i,j,7) = coordinates(5)*COS(coordinates(3))/rad_deg ! dra/dt  sky-motion
+          out_ephems(i,j,8) = coordinates(6)/rad_deg                     ! ddec/dt sky-motion
+          out_ephems(i,j,9) = phase/rad_deg                              ! phase angle
+          out_ephems(i,j,10) = solar_elongation/rad_deg                  ! solar elongation angle (deg)
+
+          CALL NULLIFY(ephemerides(1,j))
+          CALL NULLIFY(orb_lt_corr_arr(1,j))
+
+       END DO
+
+       DEALLOCATE(ephemerides, orb_lt_corr_arr)
+
+    END DO
+    DO i=1,SIZE(observers)
+       CALL NULLIFY(observers(i))
+    END DO
+    DEALLOCATE(observers)
+
+  END SUBROUTINE oorb_ephemeris_2b
 
 
 

--- a/python/test.py
+++ b/python/test.py
@@ -115,3 +115,12 @@ if __name__ == "__main__":
     for i in range(0,3):
         for j in range(0,2):
             print eph[i][j]
+
+    print("calling oorb_ephemeris_2b")
+    eph, err = pyoorb.pyoorb.oorb_ephemeris_2b(in_orbits=orbits,
+                                               in_obscode=obscode,
+                                               in_date_ephems=ephem_dates)
+    print("error code:", err)
+    for i in range(0, 3):
+        for j in range(0, 2):
+            print(eph[i][j])

--- a/python/test_2.py
+++ b/python/test_2.py
@@ -1,0 +1,177 @@
+from __future__ import print_function
+from __future__ import absolute_import
+import os
+import subprocess
+try:
+    import StringIO as i
+except ImportError:
+    from io import BytesIO as i
+import numbers
+import numpy as np
+import matplotlib.pyplot as plt
+from itertools import repeat
+import pandas as pd
+import pyoorb as oo
+
+
+import time
+
+
+def dtime(time_prev):
+    return (time.time() - time_prev, time.time())
+
+
+def pack_oorbArray(orbits):
+    """Translate orbital element dictionary (easy for humans) into pyoorb-suitable input orbit array."""
+    # Translate orbital elements into array that pyoorb will like.
+    # PyOrb wants ::
+    # 0: orbitId
+    # 1 - 6: orbital elements, using radians for angles
+    # 7: element type code, where 2 = cometary - means timescale is TT, too
+    # 8: epoch
+    # 9: timescale for the epoch; 1= MJD_UTC, 2=UT1, 3=TT, 4=TAI
+    # 10: magHv
+    # 11: G
+    elem_type = np.zeros(len(orbits)) + 2
+    epoch_type = np.zeros(len(orbits)) + 3
+    gval = np.zeros(len(orbits)) + 0.15
+    # Also, the orbitID has to be a float, rather than a string, so substitute if needed.
+    if isinstance(orbits['objid'][0], numbers.Real):
+        orbids = orbits['objid']
+    else:
+        orbids = np.arange(0, len(orbits['objid']), 1)
+    # Convert to format for pyoorb, INCLUDING converting inclination, node, argperi to RADIANS
+    oorbArray = np.column_stack((orbids, orbits['q'], orbits['e'], np.radians(orbits['i']),
+                                 np.radians(orbits['node']), np.radians(orbits['argperi']),
+                                 orbits['t_p'], elem_type, orbits['t_0'], epoch_type, orbits['H'], gval))
+    return oorbArray
+
+
+if __name__ == "__main__":
+
+    t = time.time()
+    print("starting...")
+
+    # check against OpenOrb command line
+    timespan = 1000
+    timestep = 10
+    obscode = 807
+    command = "oorb --code=%s --task=ephemeris --orb-in=test_orbits.des " \
+        " --timespan=%d --step=%d --conf=./oorb_nb.conf" % (obscode, timespan, timestep)
+    print(command)
+    d = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+    dt, t = dtime(t)
+    print("Calculating ephemerides by command line took %f s " % (dt))
+
+    d = i(d)
+    data = pd.read_table(d, delim_whitespace=True)
+    # Read the command line version back, to look for differences.
+    dt, t = dtime(t)
+    print("Turning data into dataframe %f s" % (dt))
+    print("Read %d ephemerides" % (len(data['RA'])))
+    ctimes = data['MJD_UTC/UT1'][data['#Designation'] == 1]
+    print("Created %d unique times; %d times total" % (len(np.unique(data['MJD_UTC/UT1'])), len(ctimes)))
+
+    # Read the orbits from disk.
+    # Read the orbits from disk.
+    dt, t = dtime(t)
+    orbits = pd.read_table('test_orbits.des', delim_whitespace=True)
+    newcols = orbits.columns.values
+    newcols[0] = 'objid'
+    orbits.columns = newcols
+    dt, t = dtime(t)
+    print("Reading %d orbits required %f s" % (len(orbits['q']), dt))
+    # convert orbit array to 'packed' form needed in oorb.
+    oorbArray = pack_oorbArray(orbits)
+
+    # set up oorb.
+    ephfile = os.path.join(os.getenv('OORB_DATA'), 'de430.dat')
+    oo.pyoorb.oorb_init(ephemeris_fname=ephfile)
+
+    times = np.array(ctimes)
+    # For pyoorb, we need to tag times with timescales;
+    # 1= MJD_UTC, 2=UT1, 3=TT, 4=TAI
+    ephTimes = np.array(list(zip(times, repeat(1, len(times)))), dtype='double')
+    print(times)
+    dt, t = dtime(t)
+    print("Ready for ephemeris generation .. %f s" % (dt))
+
+    # Generate ephemerides.
+    oorbephs, err = oo.pyoorb.oorb_ephemeris(in_orbits = oorbArray,
+                                             in_obscode=obscode,
+                                             in_date_ephems=ephTimes)
+    dt, t = dtime(t)
+    print("Calculating ephemerides by python required %f s" % (dt))
+
+    # 2-body test:
+    command = "oorb --code=807 --task=ephemeris --orb-in=test_orbits.des " \
+              " --timespan=%d --step=%d --conf=./oorb_2b.conf" % (timespan, timestep)
+    print(command)
+    d2 = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+    dt, t = dtime(t)
+    print("Calculating ephemerides by command line took %f s " % (dt))
+
+    d2 = i(d2)
+    data2 = pd.read_table(d2, delim_whitespace=True)
+    # Read the command line version back, to look for differences.
+    dt, t = dtime(t)
+    print("Turning data into dataframe %f s" % (dt))
+    print("Read %d ephemerides" % (len(data['RA'])))
+
+    # Generate 2-body ephemerides with python.
+    oorbephs2, err2 = oo.pyoorb.oorb_ephemeris_2b(in_orbits = oorbArray,
+                                                    in_obscode=obscode,
+                                                    in_date_ephems=ephTimes)
+    dt, t = dtime(t)
+    print("Calculating ephemerides by python using 2b only required %f s" % (dt))
+
+    # Returned ephems contain a 3-D Fortran array of ephemerides, the axes are:
+    #   [objid][time][ephemeris information element]
+    # the ephemeris information elements are (in order):
+    # distance, ra, dec, mag, ephem mjd, ephem mjd timescale, dradt(sky), ddecdt(sky)
+    # per object, per date, 8 elements (array shape is OBJ(s)/DATE(s)/VALUES)
+    # Note that ra/dec, dradt, etc. are all in DEGREES.
+    # First: (to arrange ephems for easier later use)
+    # Swap the order of the axes: DATE / Objs / values
+
+    # Unpack ephemerides.
+    times = np.ravel(oorbephs.swapaxes(0, 1).swapaxes(0, 2)[4])
+    ra = np.ravel(oorbephs.swapaxes(0, 1).swapaxes(0, 2)[1])
+    dec = np.ravel(oorbephs.swapaxes(0, 1).swapaxes(0, 2)[2])
+
+    radiff = data['RA'] - ra
+    decdiff = data['Dec'] - dec
+
+    radiff *= 3600
+    decdiff *= 3600
+
+    print("min/max ra offsets with nbody", radiff.min(), radiff.max())
+    print("min/max dec offsets with nbody", decdiff.min(), decdiff.max())
+
+    # plt.figure()
+    # plt.plot(radiff, decdiff, 'k.')
+    # plt.xlabel('Difference in RA (arcsec)')
+    # plt.ylabel('Difference in Dec (arcsec)')
+    # plt.show()
+
+    times = np.ravel(oorbephs2.swapaxes(0, 1).swapaxes(0, 2)[4])
+    ra2 = np.ravel(oorbephs2.swapaxes(0, 1).swapaxes(0, 2)[1])
+    dec2 = np.ravel(oorbephs2.swapaxes(0, 1).swapaxes(0, 2)[2])
+
+    radiff = data2['RA'] - ra2
+    decdiff = data2['Dec'] - dec2
+
+    radiff *= 3600
+    decdiff *= 3600
+
+    print("min/max ra offsets with 2body", radiff.min(), radiff.max())
+    print("min/max dec offsets with 2body", decdiff.min(), decdiff.max())
+
+
+    # Differences between 2b and nb
+    radiff = ra - ra2
+    decdiff = dec - dec2
+    radiff *= 3600
+    decdiff *= 3600
+    print("min/max ra offsets between 2body/nbody", radiff.min(), radiff.max())
+    print("min/max dec offsets between 2body/nbody", decdiff.min(), decdiff.max())


### PR DESCRIPTION
Via the python interface (pyoorb.f90): 
There is an option for orbit propagation with either 2-body or n-body integration; however, there was no option for 2-body integration if the user wanted to do ephemeris generation.  This PR adds that option. There is also an update in test.py and addition of test_2.py to test the 2-body ephemeris generation. test_2.py also compares python vs. command line calculation of ephemerides.