### PR TITLE
Correctly nullify storb in lsl (fixes bug #39)

### DIFF
--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -4906,6 +4906,7 @@ PROGRAM oorb
            CALL NULLIFY(t)
            t = copy(epoch)
         END IF
+        CALL NULLIFY(storb)
         CALL NEW(storb, obss_sep(i))        
         IF (error) THEN
            CALL errorMessage("oorb / lsl", &


### PR DESCRIPTION
I tested this and can confirm that this fixes the issue.