### PR TITLE
Fix memory leak with BC430

### DIFF
--- a/modules/integrators.f90
+++ b/modules/integrators.f90
@@ -2450,7 +2450,9 @@ CONTAINS
        END IF
 
     END DO
-
+    IF (ASSOCIATED(asteroid_masses)) THEN
+      DEALLOCATE(asteroid_masses)
+    END IF
     DEALLOCATE(wc, stat=err)
     IF (err /= 0) THEN
        error = .TRUE.


### PR DESCRIPTION
I found a memory leak when BC430 ephemerides are being used. This quick commit fixes it.