### PR TITLE
Read gdr2 designations as strings rather than integers

### DIFF
--- a/classes/Observations_class.f90
+++ b/classes/Observations_class.f90
@@ -4421,7 +4421,7 @@ CONTAINS
           END IF
 
           READ(line, *, iostat=err) solution_id, source_id, &
-               observation_id, number_mp, epoch, epoch_err, epoch_utc, &
+               observation_id, number, epoch, epoch_err, epoch_utc, &
                position(2), position(3), covariance_sys(2,2), &
                covariance_sys(3,3), covariance_sys(2,3), &
                covariance(2,2), covariance(3,3), covariance(2,3), &
@@ -4431,13 +4431,6 @@ CONTAINS
              error = .TRUE.
              CALL errorMessage("Observations / readObservationFile", &
                   "Error while reading observations from file (2).", 1)
-             RETURN
-          END IF
-
-          CALL toString(number_mp, number, error)
-          IF (error) THEN
-             CALL errorMessage("Observations / readObservationFile", &
-                  "TRACE BACK (115)", 1)
              RETURN
           END IF
 


### PR DESCRIPTION
Currently oorb reads asteroid designations in DR2 as integers and converts them to strings. However, the MPC uses 5 character designations for asteroids, e.g. asteroid 455 = 00455.
This causes oorb to consider asteroids 455 and 00455 different objects, which I don't want. So, I'm changing the designations in gdr2 files from 455 to 00455.
This isn't enough when the designation is read as an integer because as integers, 00445 = 445.
This small PR removes that particular problem and slightly simplifies the code besides.