### PR TITLE
Fixing memory leak in orbit linking

### DIFF
--- a/classes/Orbit_class.f90
+++ b/classes/Orbit_class.f90
@@ -7048,8 +7048,8 @@ CONTAINS
           DEALLOCATE(scoords_tc, stat=err)
           IF (PRESENT(partials)) THEN
              DEALLOCATE(partials, stat=err)
-             RETURN
           END IF
+          RETURN
        END IF
     END DO
 


### PR DESCRIPTION
Memory leak seems to be fixed by adding RETURN and deallocating one vector. This subroutine (getTopocentricSCoord in Orbit class) is currently not used by any other routine, so this should not break anything else.