### PR TITLE
pyoorb fixes and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ of the resulting orbits.
 In OOrb, tools for making ephemeris predictions and classification of
 objects (i.e., NEO-MBO-TNO) are also available.
 
+# Installation using conda #
 
-# Installation #
+The easiest way to install OOrb on Linux and OSX 64-bit systems is using the conda installer, which requires some form of this package manager to be installed on your system (e.g., conda, anaconda, miniconda):
+
+> `conda config --add channels conda-forge`
+> `conda install openorb`
+
+For more details on the OOrb conda package please refer to [this website](https://github.com/conda-forge/openorb-feedstock).
+
+# Manual Installation #
 
 ## Requirements ##
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ objects (i.e., NEO-MBO-TNO) are also available.
 The easiest way to install OOrb on Linux and OSX 64-bit systems is using the conda installer, which requires some form of this package manager to be installed on your system (e.g., conda, anaconda, miniconda):
 
 > `conda config --add channels conda-forge`
+
 > `conda install openorb`
 
 For more details on the OOrb conda package please refer to [this website](https://github.com/conda-forge/openorb-feedstock).
@@ -69,7 +70,7 @@ where `COMPILER` is `gfortran`, `g95`, `intel`, `absoft`, `compaq`, `ibm`, `lahe
 Now you have a working executable called `oorb` in the `OORBROOT/main/` directory. To do something useful, you need to provide the software additional data files which will be prepared in the next section.
 
 
-## Generating and updating additional data files ##
+## Generating and updating additional data files after manual installation ##
 
 ### Planetary ephemerides ###
 
@@ -125,6 +126,16 @@ Finally, you need to tell `oorb` where to find the different files. This is easi
 > `export OORB_CONF=OORBROOT/main/oorb.conf`
 
 > `export OORB_GNUPLOT_SCRIPTS_DIR=OORBROOT/gnuplot/`
+
+## Installing ephemerides files using the conda installer ##
+
+If the conda installer has been used to install OOrb, additional ephemerides files can be installed using:
+
+> `conda install openorb-data-de405`
+
+or
+
+> `conda install openorb-data-bc430`
 
 # Using oorb #
 

--- a/python/README.rst
+++ b/python/README.rst
@@ -28,9 +28,10 @@ the `sbpy.data` module for `more information
 Installation
 ------------
 
-``pyoorb`` is automatically installed alongside ``oorb`` if the conda
-installer has been used. This is the **recommended installation
-method** and by far the easiest method, as well.
+``pyoorb`` is automatically installed alongside ``oorb`` if the `conda
+installer <https://github.com/conda-forge/openorb-feedstock>`_ has
+been used. This is the **recommended installation method** and by far
+the easiest method, as well.
 
 Manual installation procedures are provided here in case you do not
 want to use the conda installer:
@@ -107,10 +108,8 @@ coordinates):
 9. `epoch` of the osculating elements (modified Julian date)
 10. `timescale type` of the epochs provided; integer value: ``UTC``:
     1, ``UT1``: 2, ``TT``: 3, ``TAI``: 4
-11. `absolute magnitude` (``KEP`` or ``CART``) or `M1` parameter
-    (``COM``)
-12. `photometric slope parameter` (``KEP`` or ``CART``) or `K1`
-    parameter (``COM``)
+11. `absolute magnitude` of the target 
+12. `photometric slope parameter` of the target 
 
 In order to provide compatibility with the underlying FORTRAN library,
 only use double values (``dtype=np.double``) and set the corresponding

--- a/python/README.rst
+++ b/python/README.rst
@@ -15,15 +15,25 @@ fitting capabilities will be added in the near future.
 
 Some documentation and installation guides can be found below - more
 documentation will be added in the near future. Please refer to the
-``test.py`` file for some example usecases, as well as `Lynne Jones'
-Jupyter notebook
-<https://github.com/rhiannonlynne/notebooks/blob/master/PyOorb%20Demo.ipynb>`_.
+documentation below, the included ``test.py`` file, as well as `Lynne
+Jones' Jupyter notebook
+<https://github.com/rhiannonlynne/notebooks/blob/master/PyOorb%20Demo.ipynb>`_
+for some example usecases.
 
-Convenience functions for the use of this module will be provided in
-the framework of the `sbpy <http://sbpy.org>`_ project.
+Convenience functions for the use of this module are provided in the
+framework of the `sbpy <http://sbpy.org>`_ project. Please refer to
+the `sbpy.data` module for `more information
+<https://sbpy.readthedocs.io/en/latest/sbpy/data.html>`_.
 
 Installation
 ------------
+
+``pyoorb`` is automatically installed alongside ``oorb`` if the conda
+installer has been used. This is the **recommended installation
+method** and by far the easiest method, as well.
+
+Manual installation procedures are provided here in case you do not
+want to use the conda installer:
 
 0. This is not a requirement but highly recommended: get the latest
    version of `Anaconda <https://www.anaconda.com/download>`_ Python
@@ -144,14 +154,20 @@ Initializing pyoorb
 ^^^^^^^^^^^^^^^^^^^
 
 Before any pyoorb functionality can be used, the module has to be
-initialized using the following lines:
+initialized using the following two lines:
+
+    >>> import pyoorb as oo
+    >>> oo.pyoorb.oorb_init()
+
+In case you installed ``pyoorb`` manually (i.e., you did not use the
+conda installer), you have to manually define which ephemerides to
+use:
 
     >>> import os
-    >>> import pyoorb as oo
     >>> ephfile = os.path.join(os.getenv('OORB_DATA'), 'de430.dat')
     >>> oo.pyoorb.oorb_init(ephfile)
 
-The initialization requires the ``'OORB_DATA'`` environment variable
+This initialization requires the ``'OORB_DATA'`` environment variable
 to be properly defined (see installation guide above). Note that in
 this example the ``DE430`` planetary and lunar ephemerides are used;
 other definition files can be used, but those have to be present in

--- a/python/pyoorb.f90
+++ b/python/pyoorb.f90
@@ -151,8 +151,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(in)           :: in_orbits ! (1:norb,1:12)
     ! in_element_type: type of output elements ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     INTEGER, INTENT(in)                                 :: in_element_type
@@ -165,8 +165,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(out)          :: out_orbits ! (1:norb,1:12)
     ! error_code: output error code
     INTEGER, INTENT(out)                                :: error_code
@@ -239,8 +239,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(in)           :: in_orbits ! (1:norb,1:12)
     ! in_epoch: epoch and timescale of output orbits:
     ! (1) modified Julian date
@@ -257,8 +257,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(out)          :: out_orbits ! (1:norb,1:12)
     ! error_code: output error code
     INTEGER, INTENT(out)                                :: error_code
@@ -386,8 +386,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(in)           :: in_orbits ! (1:norb,1:12)
     ! in_obscode: observatory code as defined by the Minor Planet Center
     CHARACTER(len=*), INTENT(in)                        :: in_obscode
@@ -697,15 +697,9 @@ CONTAINS
           phase = ACOS(cos_phase)
 
           ! apparent brightness
-          IF (in_orbits(i,8) .EQ. 2) THEN
-             ! if the target is a comet (elements type == 'COM')
-             vmag = in_orbits(i,11)+5*LOG10(coordinates(1))+2.5*in_orbits(i,12)*LOG10(SQRT(heliocentric_r2))
-          ELSE
-             ! if the target is not a comet (any other elements type)
-             vmag = getApparentHGMagnitude(H=in_orbits(i,11), &
+          vmag = getApparentHGMagnitude(H=in_orbits(i,11), &
                G=in_orbits(i,12), r=SQRT(heliocentric_r2), &
                Delta=coordinates(1), phase_angle=phase)
-          END IF
 
           IF (error) THEN
              CALL errorMessage('oorb / ephemeris', &
@@ -889,8 +883,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(in)           :: in_orbits ! (1:norb,1:12)
     ! in_obscode: observatory code as defined by the Minor Planet Center
     CHARACTER(len=*), INTENT(in)                        :: in_obscode
@@ -1106,15 +1100,9 @@ CONTAINS
           phase = ACOS(cos_phase)
 
           ! apparent brightness
-          IF (in_orbits(i,8) .EQ. 2) THEN
-             ! if the target is a comet (elements type == 'COM')
-             vmag = in_orbits(i,11)+5*LOG10(coordinates(1))+2.5*in_orbits(i,12)*LOG10(SQRT(heliocentric_r2))
-          ELSE
-             ! if the target is not a comet (any other elements type)
-             vmag = getApparentHGMagnitude(H=in_orbits(i,11), &
+          vmag = getApparentHGMagnitude(H=in_orbits(i,11), &
                G=in_orbits(i,12), r=SQRT(heliocentric_r2), &
                Delta=coordinates(1), phase_angle=phase)
-          END IF
 
           IF (error) THEN
              CALL errorMessage('oorb / ephemeris', &
@@ -1169,8 +1157,6 @@ CONTAINS
           CALL NULLIFY(ephemerides(1,j))
           CALL NULLIFY(orb_lt_corr_arr(1,j))
 
-          WRITE (*,*) true_anom/rad_deg
-          
        END DO
        CALL NULLIFY(orb_arr(1))
        DEALLOCATE(ephemerides, orb_lt_corr_arr)
@@ -1215,8 +1201,8 @@ CONTAINS
     ! (8) orbital elements type ('CART': 1, 'COM': 2, 'KEP': 3, 'DEL': 4, 'EQX': 5)
     ! (9) epoch in mjd
     ! (10) time scale type ('UTC': 1, 'UT1': 2, 'TT': 3, 'TAI': 4)
-    ! (11) target absolute magnitude H/M1 parameter for comets ('COM' elements type)
-    ! (12) target slope parameter G/K1 parameter for comets ('COM' elements type)
+    ! (11) target absolute magnitude H
+    ! (12) target slope parameter G
     REAL(8),DIMENSION(in_norb,12), INTENT(in)             :: in_orbits ! (1:norb,1:12)
     ! in_covariances: input covariance matrices for orbital elements
     REAL(8), DIMENSION(in_norb,6,6), INTENT(in)           :: in_covariances ! (1:norb,1:6,1:6)


### PR DESCRIPTION
this pr comes with the following changes:
* pyoorb: fix to #70: brightness predictions are now always in the HG system, a useless write statement was removed
* conda installer guidelines added to oorb/README
* conda installer guidelines added to oorb/pyoorb/README; docs updated