### PR TITLE
Hooking up OpenOrb to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/*.pyf
 build/version.h
 python/pyoorb.name
 python/pyoorb.sp_dir
+*.gcov
+*.gcda
+*.gcno

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,22 @@ else
 	@ echo WARNING: Not running pyoorb integration tests as data/de430.dat is not present. Run "'make ephem'" to build it first.
 endif
 endif
+
+#
+# Compute test coverage. Uses 'gcov' to compute how much of the code has
+# been covered by tests.  To run this rule you must have configured the
+# project with gfortran and the --coverage flag, and have gcov installed.
+#
+# This target is mainly intented to be driven from CI services and
+# visualized at codecov.io.  See https://codecov.io/gh/mjuric/oorb for
+# outputs.
+#
+# Google for 'lcov' if you want to create local visualizations.
+#
+.PHONY: coverage coverage-prereq
+coverage: coverage-prereq test
+	(cd build && gcov -b -o . *.o ../classes/*.f90 ../modules/*.f90 ../main/*.f90 ../prefix.h ../python/*.f90)
+
+coverage-prereq:
+	@test ! -z "$(findstring -lgcov, $(ADDLIBS))" || { echo "The project must be ./configure-d with --coverage flag to run 'make coverage'."; exit -1; }
+	@hash gcov 2>/dev/null || { echo "You need to have gcov installed to run test coverage analysis." && exit -1; }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-OpenOrb (or OOrb) is an open-source orbit-computation package.
+# OpenOrb (or OOrb), an open-source orbit-computation package.
+
+[![Build Status](https://dev.azure.com/mjuric/oorb/_apis/build/status/mjuric.oorb?branchName=master)](https://dev.azure.com/mjuric/oorb/_build/latest?definitionId=1?branchName=master)
 
 More detailed documentation is available by doing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenOrb (or OOrb), an open-source orbit-computation package.
 
 [![Build Status](https://dev.azure.com/mjuric/oorb/_apis/build/status/mjuric.oorb?branchName=master)](https://dev.azure.com/mjuric/oorb/_build/latest?definitionId=1?branchName=master)
+[![Test Coverage](https://codecov.io/gh/mjuric/oorb/branch/master/graph/badge.svg)](https://codecov.io/gh/mjuric/oorb)
+
 
 More detailed documentation is available by doing
 
@@ -174,6 +176,20 @@ override default paths and/or executable names:
   * `--with-f2py=<f2py compuler name/path>`
   * `--with-pytest=<pytest executable name/path>`
 
+
+### Building with test coverage logging (for developers)
+
+Running configure with:
+```bash
+./configure --coverage
+```
+will link OpenOrb with [`gcov`
+coverage](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) libraries. These
+allow the developers to monitor the extent to which the code is covered by
+the test suite.
+
+See additional information in the comments next to the `coverage` target in
+the [Makefile](Makefile).
 
 ## Generating and updating additional data files after building from source ##
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       python $SRCDIR/python/test.py
     displayName: 'Test'
 - job: 'Ubuntu_1604_py35'
-  displayName: 'Ubuntu 16.04 Py35'
+  displayName: 'Ubuntu 16.04 Py35 (w. codecov)'
   condition: eq('a', 'a')
   pool:
     vmImage: 'Ubuntu 16.04'
@@ -54,11 +54,17 @@ jobs:
       # Intentionally install python 2, to verify it doesn't get confused
       sudo apt-get install -y git gfortran build-essential python-dev python-numpy python-pytest
 
-      ./configure gfortran opt --prefix=/opt/test/openorb --with-f2py=f2py3 --with-python=python3 --with-pytest=py.test-3 --with-pyoorb
+      ./configure gfortran opt --prefix=/opt/test/openorb --with-f2py=f2py3 --with-python=python3 --with-pytest=py.test-3 --with-pyoorb --coverage
       make -j8
       make ephem -j8
-      make test
+      make coverage
+
+      bash <(curl -s https://codecov.io/bash) -Z
+
       sudo make install
+    env:
+      # NOTE: you must define this *secret* variable in Azure Pipelines
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
     displayName: 'Build'
   - script: |
       set -xe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,97 @@
+#
+# Parallel build
+#
+jobs:
+- template: azure-tpl-jobs.yml
+  parameters:
+    name: 'Linux_Conda'
+    vmImage: 'Ubuntu 16.04'
+- template: azure-tpl-jobs.yml
+  parameters:
+    name: 'MacOS_Conda'
+    vmImage: 'macOS-10.13'
+- job: 'Ubuntu_1604_py27'
+  condition: eq('a', 'a')
+  displayName: 'Ubuntu 16.04 Py27'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+  - script: |
+      set -xe
+      sudo apt-get update
+      sudo rm -f /usr/bin/conda
+      # sudo apt-get install -y git gfortran build-essential python3-dev python3-numpy python3-pytest
+      sudo apt-get install -y git gfortran build-essential python-dev python-numpy python-pytest
+
+      ./configure gfortran opt --prefix=/opt/test/openorb --with-pyoorb
+      make -j8
+      make ephem -j8
+      make test
+      sudo make install
+    displayName: 'Build'
+  - script: |
+      set -xe
+      SRCDIR=$PWD
+      cd /
+      python -c "import pyoorb; print('success.')"
+      python $SRCDIR/python/test.py
+    displayName: 'Test'
+- job: 'Ubuntu_1604_py35'
+  displayName: 'Ubuntu 16.04 Py35'
+  condition: eq('a', 'a')
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+  - script: |
+      set -xe
+      sudo apt-get update
+      sudo rm -f /usr/bin/conda
+      sudo apt-get install -y git gfortran build-essential python3-dev python3-numpy python3-pytest
+      # Intentionally install python 2, to verify it doesn't get confused
+      sudo apt-get install -y git gfortran build-essential python-dev python-numpy python-pytest
+
+      ./configure gfortran opt --prefix=/opt/test/openorb --with-f2py=f2py3 --with-python=python3 --with-pytest=py.test-3 --with-pyoorb
+      make -j8
+      make ephem -j8
+      make test
+      sudo make install
+    displayName: 'Build'
+  - script: |
+      set -xe
+      SRCDIR=$PWD
+      cd /
+      python3 -c "import pyoorb; print('success.')"
+      python3 $SRCDIR/python/test.py
+    displayName: 'Test'
+- job: 'Ubuntu_1604_no_pyoorb'
+  condition: eq('a', 'a')
+  displayName: 'Ubuntu 16.04 (w/o pyoorb)'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+  - script: |
+      set -xe
+      sudo apt-get update
+      sudo rm -f /usr/bin/conda
+      sudo apt-get install -y git gfortran build-essential
+
+      ./configure gfortran opt
+      make -j8
+      make ephem -j8
+
+      sudo apt-get install -y python-pytest
+      make test
+      sudo make install
+    displayName: 'Build'
+  - script: |
+      set -xe
+      echo PATH="$PATH"
+      ls -l /usr/local/{bin,etc,lib,share}
+      [[ $(oorb --help | head -n 1) == "Usage:" ]] && echo yes
+    displayName: 'Test'

--- a/azure-tpl-jobs.yml
+++ b/azure-tpl-jobs.yml
@@ -1,0 +1,56 @@
+# Azure Pipelines CI job template
+
+parameters:
+  name: ''
+  vmImage: ''
+
+jobs:
+- job: ${{ parameters.name }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  strategy:
+    matrix:
+      py27:
+        conda.py: 2.7
+      py36:
+        conda.py: 3.6
+      py37:
+        conda.py: 3.7
+  steps:
+  - checkout: self
+    fetchDepth: 1
+  - script: |
+      set -xe
+      # deal with an annoying nvm bug on macOS (cosmetic issue):
+      #   - https://github.com/Microsoft/vscode-docs/blob/master/docs/editor/integrated-terminal.md#why-is-nvm-complaining-about-a-prefix-option-when-the-integrated-terminal-is-launched
+      #   - https://github.com/creationix/nvm/issues/1690
+      #   - https://github.com/creationix/nvm/issues/1245
+      rm -rf ~/.nvm
+
+      export PATH="$CONDA/bin:$PATH"
+      conda create --yes --quiet -n oorb-dev python=$CONDA_PY numpy pytest $( [[ $(uname) == Darwin ]] && echo gfortran_osx-64 || echo gfortran_linux-64)
+      source activate oorb-dev
+
+      # conda's gfortran on Linux does not install a binary named 'gfortran'
+      echo "gfortran = $(which gfortran)"
+      [[ ! -f "$CONDA_PREFIX/bin/gfortran" && ! -z "$GFORTRAN" ]] && ln -s "$GFORTRAN" "$CONDA_PREFIX/bin/gfortran"
+      echo "gfortran = $(which gfortran)"
+
+      # configure and run
+      ./configure gfortran opt --prefix=/opt/test/openorb --with-pyoorb
+      make -j8
+      make ephem -j8
+      make test
+      sudo make install
+    displayName: 'Build'
+  - script: |
+      set -xe
+
+      export PATH="$CONDA/bin:$PATH"
+      source activate oorb-dev
+
+      SRCDIR=$PWD
+      cd /
+      python -c "import pyoorb; print('success.')"
+      python $SRCDIR/python/test.py
+    displayName: 'Test'

--- a/build/Makefile
+++ b/build/Makefile
@@ -35,6 +35,7 @@ clean:
 	rm -f ../lib/liboorb.{$(LIBEXT),a}
 	rm -rf *.pyf ../python/pyoorb.{so,dylib} ../python/pyoorb.*.so ../python/pyoorb.{name,sp_dir} _pyoorb_build
 	rm -rf ../bin ../lib
+	find .. -name '*.gcno' -o -name '*.gcda' -o -name '*.gcov' -exec rm {} \;
 
 #
 # Convenience so we can run 'make oorb' (instead of 'make ../bin/oorb')
@@ -58,7 +59,7 @@ $(addprefix ../bin/, $(PROGRAMS)): ../bin/%: ../main/%
 	cp -a $< $@
 
 $(addprefix ../main/, $(PROGRAMS)): ../main/%: %.o ../lib/liboorb.a
-	$(FC) $(FCOPTIONS) $^ -o $@.tmp
+	$(FC) $(FCOPTIONS) $^ $(ADDLIBS) -o $@.tmp
 	fix-rpath.sh $@.tmp
 	mv $@.tmp $@
 
@@ -120,7 +121,7 @@ pyoorb: ../lib/$(PYOORB_SO)
 	}; \
 	: \ "# We override whatever is in F77= as that confuses f2py when used with Intel Compilers (conda compiler packages set it)"
 	F77= $(F2PY) --quiet -m pyoorb pyoorb.o pyoorb.pyf ../lib/liboorb.a --build-dir ./_pyoorb_build -c --noarch \
-	        $(F2PY_FCOMPILER) --f90exec=$(FC) --f90flags="$(FC_INC)../build" && \
+	        $(F2PY_FCOMPILER) --f90exec=$(FC) --f90flags="$(FC_INC)../build $(FCOPTIONS)" $(ADDLIBS) && \
 	mv $(PYOORB_SO) ../python
 	@ echo
 	@ # FIXME: this exists so `sudo make install` knows what to install. It's hacky this way

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 2
+  round: down
+  range: "0..100"

--- a/configure
+++ b/configure
@@ -65,6 +65,13 @@ do
 			eval "$(option_to_varname $key)=1"
 			shift;
 		;;
+		
+		--coverage)
+			COVERAGE=on
+			ADDLIBS="$ADDLIBS -lgcov"
+			ADDOPTS="$ADDOPTS -coverage"
+			shift;
+		;;
 
 		*)
 		POSITIONAL+=("$1")
@@ -73,6 +80,12 @@ do
 	esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
+
+# --coverage only works with gfortran; verify gfortran is being used
+if [[ ! -z $COVERAGE && $1 != gfortran ]]; then
+	echo "Error: --coverage option only works with the gfortran compiler".
+	exit -1
+fi
 
 # Make sure $PREFIX is an absolute path
 if [[ $PREFIX != /* ]]; then
@@ -180,9 +193,9 @@ elif [[ $1 == gfortran ]] ; then
 
     echo 'FC = $(FC_GFORTRAN)' > $include_file
     if [[ $2 == opt ]] ; then
-	echo 'FCOPTIONS = $(FCOPTIONS_OPT_GFORTRAN)' >> $include_file
+	echo 'FCOPTIONS = $(FCOPTIONS_OPT_GFORTRAN)'"$ADDOPTS" >> $include_file
     else
-	echo 'FCOPTIONS = $(FCOPTIONS_DEB_GFORTRAN)' >> $include_file
+	echo 'FCOPTIONS = $(FCOPTIONS_DEB_GFORTRAN)'"$ADDOPTS" >> $include_file
     fi
     echo 'FC_INC = $(FC_INC_GFORTRAN)' >> $include_file
     echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
@@ -213,3 +226,4 @@ echo "PYOORB=$PYOORB" >> "$include_file"
 echo "PYTHON=$PYTHON" >> "$include_file"
 echo "F2PY=$F2PY"     >> "$include_file"
 echo "PYTEST=$PYTEST" >> "$include_file"
+echo "ADDLIBS=$ADDLIBS" >> "$include_file"

--- a/data/JPL_ephemeris/Makefile
+++ b/data/JPL_ephemeris/Makefile
@@ -101,11 +101,11 @@ test : $(TESTER) $(EPH_BIN) testpo.$(EPH_TYPE)
 
 # Compile ascii-to-binary converter:
 $(CONVERTER): $(CONV_SRC) ../../lib/liboorb.a
-	$(FC) -o $(CONVERTER) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a 
+	$(FC) -o $(CONVERTER) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a $(ADDLIBS) 
 
 # Compile tester:
 $(TESTER): $(TEST_SRC) ../../lib/liboorb.a
-	$(FC) -o $(TESTER) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a
+	$(FC) -o $(TESTER) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a $(ADDLIBS) 
 
 # Download individual ephemeris files (via a temp file, so that partial downloads aren't
 # seen as successful by make


### PR DESCRIPTION
Hi @mgranvik, @Siltala et al.:

This PR adds the configuration files needed to automatically run builds and tests on [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) continuous integration service, and the [codecov.io](http://codecov.io) code coverage visualization service.

Once hooked up, Azure's CI will automatically builds oorb on a matrix of operating systems and Python versions every time a new commit is pushed onto master, and also whenever a pull request is made (so you'll know if the PR breaks existing code).

Eight builds are made in total (macOS w. conda w. py27, 36, 37; Ubuntu w. conda w. py27, 36, 37; and Ubuntu with system Python 2.7 and 3.5) and it runs tests on all of them. The builds are done in parallel and typically take 3-4 minutes (for all of them). It's easy to add more systems and/or different compilers. It also makes a `gcov` run to compute test coverage, and visualizes them using codecov.io's service.

Once you merge this PR, to hook it up to Pipelines and codecov.io you'll need to open an [Azure DevOps](https://azure.microsoft.com/en-us/services/devops/) account, as well as a [codecov.io](http://codecov.io) account. After that, you can either follow the (somewhat cryptic and verbose) [instructions](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops) on connecting Pipelines to the repo (and then the same for codecov), OR we can arrange to meet on a quick phonecon (or on gitter) and I can walk you through it in ~10 minutes. I'd recommend the latter :).

Once it's done, here's an example of how it works (on my fork):
* See the nice badge (== [![Build Status](https://dev.azure.com/mjuric/oorb/_apis/build/status/mjuric.oorb?branchName=master)](https://dev.azure.com/mjuric/oorb/_build/latest?definitionId=1?branchName=master)) in the README.md at https://github.com/mjuric/oorb
* Clicking on the badge gets you to https://dev.azure.com/mjuric/oorb/_build/latest?definitionId=1?branchName=master which lists the details of the recent builds. If the build failed, you can inspect the logs to figure out why. [Here's](https://dev.azure.com/mjuric/oorb/_build/results?buildId=82) an example of one that succeeded.
* [![Test Coverage](https://codecov.io/gh/mjuric/oorb/branch/master/graph/badge.svg)](https://codecov.io/gh/mjuric/oorb)
