### PR TITLE
Fix integrator failure when no perturbers are set

### DIFF
--- a/modules/integrators.f90
+++ b/modules/integrators.f90
@@ -2129,6 +2129,7 @@ CONTAINS
     INTEGER :: i, iaddit, j, k, l, err, naddit
 
     naddit = 0
+    err = 0
 
     ! Number of basic perturbers, that is, perturbers whose orbits are
     ! not integrated.
@@ -2462,7 +2463,9 @@ CONTAINS
     IF (ASSOCIATED(asteroid_masses)) THEN
       DEALLOCATE(asteroid_masses)
     END IF
-    DEALLOCATE(wc, stat=err)
+    IF (ALLOCATED(wc)) THEN
+      DEALLOCATE(wc, stat=err)
+    END IF
     IF (err /= 0) THEN
        error = .TRUE.
        RETURN


### PR DESCRIPTION
Currently the Bulirsch-Stoer integrator fails if n-body integration is being used with all perturbers disabled (I suppose I'm the only one who ever does that?)
This short PR fixes the issue.