### PR TITLE
First steps for replacing oorb's linear algebra functions with those of LAPACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ To build OOrb:
   * GNU `make`
   * a Fortran 90/95 compiler (`gfortran` is best tested)
   * `curl` (usually comes with macOS and Linux by default)
+  * The `lapack` library (comes with macOS by default)
 
 To build the python bindings:
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -79,12 +79,12 @@ liboorb: ../lib/liboorb.$(LIBEXT) ../lib/liboorb.a
 LIBOBJECTS=$(notdir ${LIBSOURCES:.f90=.o})
 ../lib/liboorb.$(LIBEXT): $(LIBOBJECTS)
 	mkdir -p ../lib
-	$(FC) $(FCOPTIONS) $(FC_SHARED) $(LIBOBJECTS) -o $@
+	$(FC) $(FCOPTIONS) $(FC_SHARED) $(LIBOBJECTS) $(ADDLIBS) -o $@
 
 ../lib/liboorb.a: $(LIBOBJECTS)
 	mkdir -p ../lib
 ifeq ($(shell uname),Darwin)
-	libtool -static -no_warning_for_no_symbols $(LIBOBJECTS) -o $@
+	libtool -static -no_warning_for_no_symbols $(LIBOBJECTS) -o $@ 
 else
 	ar rcs $@ $(LIBOBJECTS)
 endif

--- a/configure
+++ b/configure
@@ -46,7 +46,7 @@ PYOORB=0
 PYTHON=python
 F2PY="f2py"
 PYTEST="py.test"
-ADDLIBS=
+ADDLIBS="-llapack"
 ADDOPTS=
 COVERAGE=
 


### PR DESCRIPTION
I think that this is now ready for merging. The new code produces very similar (but not always 100% equivalent) results to the old code and, based on my limited testing, seems mathematically correct.

This PR replaces oorb's LU and Cholesky factorization and matrix inversion based on both with functions from LAPACK. 

As far as the rest of the code outside linal.f90 is concerned, nothing has changed (the 'old' functions are there and are used in the same way but, inside linal.f90, the internal behavior of the functions has.)

There may be room for using LAPACK elsewhere in the code, but that can always be done later (?)
