### PR TITLE
bugfix: make depends broken if $FC wasn't externally set

### DIFF
--- a/build-tools/make-fortran-deps.sh
+++ b/build-tools/make-fortran-deps.sh
@@ -6,6 +6,14 @@
 #       http://lagrange.mechse.illinois.edu/f90_mod_deps/
 #
 
+# Verify we're using gfortran -- ifort is known to be buggy with dependency
+# generation
+
+($FC --version 2>/dev/null | grep -q "GNU Fortran") || {
+	echo "*** Running 'make depends' requires the compiler to be gfortran." >&2
+	exit -1
+}
+
 $FC -cpp -I. -M "$@" | while read line; do
 	IFS=":" read -r TARGETS DEPS <<< "$line"
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -159,7 +159,7 @@ endif
 #
 .PHONY: depends
 depends: clean version.h
-	make-fortran-deps.sh $(ALLSOURCES) > make.depends
+	FC=$(FC) make-fortran-deps.sh $(ALLSOURCES) > make.depends
 
 #
 # Recipes to build individual files, which are called by the rules generated


### PR DESCRIPTION
This fixes #89.