### PR TITLE
Update getBC430 script

### DIFF
--- a/data/getBC430
+++ b/data/getBC430
@@ -30,7 +30,7 @@
 # Author: LS
 # Date:   2018-02-05
 
-curl -L -O -\# -C - -f http://staff.not.iac.es/~siltala/asteroid_indices.txt
-curl -L -O -\# -C - -f http://staff.not.iac.es/~siltala/asteroid_masses.txt
-curl -L -O -\# -C - -f http://staff.not.iac.es/~siltala/asteroid_ephemeris.txt
+curl -L -O -\# -C - -f https://zenodo.org/record/3558850/files/BC430.tar.gz
+tar xzf BC430.tar.gz
+rm BC430.tar.gz
 


### PR DESCRIPTION
New attempt to fix #100 .
This updates getBC430 such that it downloads the BC430 data files from Zenodo, unpacks the archive (this assumes that the user has tar in stalled, but I would be surprised if someone -didn't- have it installed) and finally removes the tar.gz archive, leaving only the relevant data files in the folder.