### PR TITLE
Fix reading BC430 masses with non-consecutive perturbers enabled

### DIFF
--- a/modules/planetary_data.f90
+++ b/modules/planetary_data.f90
@@ -1546,7 +1546,7 @@ CONTAINS
        INQUIRE(unit=lu, opened=used, iostat=err)
        IF (err /= 0) THEN
           error = .TRUE.
-          WRITE(0,*) "JPL_ephemeris_init(): Error when inquiring for status of logical unit."
+          WRITE(0,*) "BC_ephemeris_init(): Error when inquiring for status of logical unit."
           RETURN
        END IF
        IF (used) THEN
@@ -1556,7 +1556,7 @@ CONTAINS
           ! A free unit could not be found:
           IF (count > max_lu) THEN
              error = .TRUE.
-             WRITE(0,*) "JPL_ephemeris_init(): Could not find a free logical unit."
+             WRITE(0,*) "BC_ephemeris_init(): Could not find a free logical unit."
              RETURN
           END IF
           lu = lu + 1
@@ -1613,6 +1613,8 @@ CONTAINS
        IF (asteroid_masks(i)) THEN
           READ(lu,*) asteroid_masses(k)
           k = k + 1
+        ELSE ! This happens if an asteroid has been commented out. This read statement's purpose
+          READ(lu,*)  ! is to advance to a new line without storing the mass anywhere.
        END IF
     END DO
     CLOSE(unit=lu)


### PR DESCRIPTION
This PR should fix #97. 

It turns out that with non-consecutive perturbers enabled, the masses (in asteroids_masses.txt) were read from incorrect lines.

I tested that the fix works by computing a lsl orbit for an asteroid with a close encounter with Vesta by enabling Vesta's perturbations but not those of Ceres and Pallas, which works well with this patch but not without.
