### PR TITLE
getID_SO: check if the object's ID is actually initialized

### DIFF
--- a/classes/StochasticOrbit_class.f90
+++ b/classes/StochasticOrbit_class.f90
@@ -3768,6 +3768,13 @@ CONTAINS
     IMPLICIT NONE
     TYPE (StochasticOrbit), INTENT(in) :: this
 
+    IF (TRIM(this%id_prm) == "") THEN
+       error = .TRUE.
+       CALL errorMessage("StochasticOrbit / getID", &
+         "Object does not contain an ID.", 1)
+       RETURN
+    END IF
+
     getID_SO = this%id_prm
 
   END FUNCTION getID_SO


### PR DESCRIPTION
Just a simple commit to raise an error if getID is called on a storb object that doesn't actually have an ID instead of returning a blank string.