### PR TITLE
Use the UTC epoch instead of TCB when reading Gaia data

### DIFF
--- a/classes/Observations_class.f90
+++ b/classes/Observations_class.f90
@@ -4787,7 +4787,7 @@ CONTAINS
              discovery = .FALSE.
           END IF
 
-          CALL NEW(t, mjd_tcb + epoch, "TCB")
+          CALL NEW(t, mjd_tcb + epoch_utc, "UTC")
           IF (error) THEN
              CALL errorMessage("Observations / readObservationFile", &
                   "TRACE BACK (115)", 1)


### PR DESCRIPTION
As discussed in private email, it seems there's currently an inaccuracy of ~10 ms inside oorb in observation epochs when using Gaia DR2 data.

It turns out that the problem has something to do with timescale conversions; when using the UTC observation epochs from the .gdr2 data files directly, the problem seems to disappear. This commit does just that and thus works around the problem.