### PR TITLE
Set output filenames based on --orb-out if given

### DIFF
--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -973,6 +973,8 @@ PROGRAM oorb
   IF (LEN_TRIM(orb_out_fname) == 0) THEN
      lu_orb_out = stdout
   ELSE
+     indx = INDEX(orb_out_fname,".",back=.TRUE.)
+     out_fname = orb_out_fname(1:indx-1)
      CALL NEW(orb_out_file,TRIM(orb_out_fname))
      CALL OPEN(orb_out_file)
      IF (error) THEN


### PR DESCRIPTION
Currently oorb sets an output filename for things e.g. lsl's .ls file based on the filename of the input observations. This changes that behavior to set the output name based on --orb-out instead. If it is not given, we fall back to the old behavior.

The advantage here is that this is a LOT more convenient during development and also certain use cases; under the current scheme if you calculate several lsl orbits based on the same data files the residuals for each of these orbits all end up in the same file and it gets very difficult to figure out which is which. With this commit that is no longer an issue.  