### PR TITLE
Install CI numpy with pip rather than homebrew

### DIFF
--- a/.github/workflows/CI_tests.yml
+++ b/.github/workflows/CI_tests.yml
@@ -93,9 +93,8 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Compile oorb with gfortran
       run: |
-        brew install numpy
-        pip3 install -U pytest
-        ./configure gfortran opt --with-pyoorb --with-f2py=f2py3 --with-python=python3
+        pip3 install -U pytest numpy
+        ./configure gfortran opt --with-pyoorb --with-python=python3
         make -j3
     - name: Build ephemerides
       run: |


### PR DESCRIPTION
This works around #112 and doesnt affect any functionality outside the CI.