### PR TITLE
Add more gfortran optimizations

### DIFF
--- a/make.config
+++ b/make.config
@@ -103,8 +103,8 @@ FC_SHARED_G95        = -dynamiclib -single_module -read_only_relocs suppress
 
 # gfortran: 
 FC_GFORTRAN               = gfortran
-FCOPTIONS_OPT_GFORTRAN    = -O3 -fPIC -std=f95 -fall-intrinsics -cpp
-FCOPTIONS_DEB_GFORTRAN    = -g -O0 -fPIC -fbounds-check -pedantic -Wall -std=f95 -fall-intrinsics -cpp
+FCOPTIONS_OPT_GFORTRAN    = -O2 -fPIC -std=f95 -fall-intrinsics -cpp -flto -pipe -funroll-loops -fstack-arrays -fno-protect-parens
+FCOPTIONS_DEB_GFORTRAN    = -g -O0 -fPIC -fbounds-check -pedantic -Wall -std=f95 -fall-intrinsics -cpp -pipe
 FC_INC_GFORTRAN           = -I
 FC_SHARED_GFORTRAN        = -shared
 F2PY_FCOMPILER_GFORTRAN   = --fcompiler=gnu95


### PR DESCRIPTION
This adjusts the default optimization flags for gfortran. -O3 is switched to -O2 (which for oorb, and some other programs, appears to be slightly faster?), link-time optimizations are added (-flto) among with loop unrolling and 2 optimizations which ifort apparently uses with O3 already (and thus oorb) 

Based on my testing, on my system this gives a ~11% speedup for running n-body lsl computations and at least in the CI none of the results change. Compilation time however almost doubles but I at least think it's worth it. Further testing is welcome!
For my test I ran lsl four times with both these flags and the old optimizations and compared the mean run times of each (174 seconds with the new flags, 196 with the old)
I also note that I've been using these optimization flags on my end for a while now with no problems.