### PR TITLE
Mass estimation code updates

### DIFF
--- a/classes/StochasticOrbit_class.f90
+++ b/classes/StochasticOrbit_class.f90
@@ -19960,6 +19960,7 @@ CONTAINS
 
           END IF
        END DO
+       DEALLOCATE(residuals%vectors(i)%elements)
        DEALLOCATE(obs_masks)
     END DO
     DEALLOCATE(residuals%vectors)

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -9746,11 +9746,7 @@ PROGRAM oorb
 
      DO j=1, SIZE(mcmc_orb_arr,dim=2)
          DO i=1, SIZE(storb_arr_in)
-           IF (ASSOCIATED(mcmc_orb_arr)) THEN
-               orb_arr(i) = mcmc_orb_arr(i,j)
-           ELSE
-               orb_arr(i) = orb_arr_in(i)
-           END IF
+           orb_arr(i) = mcmc_orb_arr(i,j)
            CALL setParameters(orb_arr(i), dyn_model=dyn_model, &
                  perturbers=perturbers, integrator=integrator, &
                  integration_step=integration_step)


### PR DESCRIPTION
This PR removes an unnecessary (and wrong) if block from the MCMC residual printing task and also fixes a minor memory leak that slipped into my residual printing function.