### PR TITLE
massEstimation_mcmc: minor output fix

### DIFF
--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -2152,7 +2152,8 @@ CONTAINS
     END DO
 
     ! ----------------------------- MCMC IS DONE -----------------------
-    !final_solutions = accepted_solutions
+    ! We have to print out the number of accepted proposals for the last one separately.
+    WRITE(getUnit(mcmc_out_file), "(1(I5))", advance="yes") 1
     ! Post-fit computation of statistics for masses
     IF (last) THEN
        ALLOCATE(indx_arr(norb))


### PR DESCRIPTION
A quick fix for a MCMC bug where the number of accepted proposals was not printed out for the last accepted one (which is always 1)
Not really interesting in a scientific sense but it does solve problems with some plotting scripts of mine (in the past I've just removed the single troublesome line manually from the result files..)