### PR TITLE
Datafile IO updates

### DIFF
--- a/classes/Base_class.f90
+++ b/classes/Base_class.f90
@@ -114,7 +114,6 @@ MODULE Base_cl
   INTEGER, PARAMETER :: DESIGNATION_LEN = 16
   INTEGER, PARAMETER :: OBSY_CODE_LEN = 4
   CHARACTER(len=FNAME_LEN) :: OORB_DATA_DIR
-  INCLUDE "../prefix.h"
 
   CHARACTER(len=FNAME_LEN), PARAMETER :: EPH_FNAME = "de430.dat"
   ! OBS CODES
@@ -620,22 +619,6 @@ CONTAINS
     rotationMatrix(i3,i3) = COS(alpha)
 
   END FUNCTION rotationMatrix
-
-
-  FUNCTION resolveDirectory(subdir, envvar) RESULT(s2)
-    CHARACTER(*), INTENT(IN) :: subdir, envvar
-    CHARACTER(FNAME_LEN) :: s2
-
-    ! If overriden by an environmental variable, prefer that
-    CALL getenv(envvar, s2)
-    IF (LEN_TRIM(s2) /= 0) THEN
-       RETURN
-    END IF
-
-    ! Otherwise, return <PREFIX>/<subdir>
-    s2 = TRIM(PREFIX) // "/" // subdir
-
-  END FUNCTION resolveDirectory
 
 
   SUBROUTINE setAccessToDataFiles()

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -512,8 +512,8 @@ PROGRAM oorb
      STOP
   END IF
 
-  ! Set path to Gnuplot scripts using environment variable:
-  CALL getenv("OORB_GNUPLOT_SCRIPTS_DIR", gnuplot_scripts_dir)
+  ! Set path to Gnuplot scripts using the environment variable if it exists:
+  gnuplot_scripts_dir = resolveDirectory("share/oorb/gnuplot", "OORB_GNUPLOT_SCRIPTS_DIR")
 
   ! Read observation file if given:
   obs_fname = get_cl_option("--obs-in="," ")

--- a/modules/planetary_data.f90
+++ b/modules/planetary_data.f90
@@ -56,6 +56,7 @@ MODULE planetary_data
   USE parameters
   USE linal
   USE sort
+  USE utilities
   IMPLICIT NONE
   PRIVATE
   CHARACTER(len=FNAME_LEN), PARAMETER :: EPH_FNAME = 'de430.dat'
@@ -181,9 +182,6 @@ MODULE planetary_data
      MODULE PROCEDURE BC_masses_r8
   END INTERFACE BC_masses
 CONTAINS
-
-
-
 
 
   !! *Description*:
@@ -1566,7 +1564,9 @@ CONTAINS
           done = .TRUE.
        END IF
     END DO
-    CALL getenv("OORB_DATA", OORB_DATA_DIR)
+
+    OORB_DATA_DIR = resolveDirectory("share/oorb", "OORB_DATA")
+
     IF (LEN_TRIM(OORB_DATA_DIR) == 0) THEN
        OORB_DATA_DIR = "."
     END IF

--- a/modules/utilities.f90
+++ b/modules/utilities.f90
@@ -33,7 +33,7 @@ MODULE utilities
   USE parameters
 
   IMPLICIT NONE
-
+  INCLUDE "../prefix.h"
   PRIVATE :: integerToArray_ri8
   PRIVATE :: arrayToInteger_r8i8
   PRIVATE :: arrayToReal_r8r16
@@ -1666,6 +1666,21 @@ CONTAINS
 
   END SUBROUTINE toString_r8
 
+  !! Moved from Base_class.f90.
+  FUNCTION resolveDirectory(subdir, envvar) RESULT(s2)
+    CHARACTER(*), INTENT(IN) :: subdir, envvar
+    CHARACTER(FNAME_LEN) :: s2
+
+    ! If overriden by an environmental variable, prefer that
+    CALL getenv(envvar, s2)
+    IF (LEN_TRIM(s2) /= 0) THEN
+       RETURN
+    END IF
+
+    ! Otherwise, return <PREFIX>/<subdir>
+    s2 = TRIM(PREFIX) // "/" // subdir
+
+  END FUNCTION resolveDirectory
 
 
 


### PR DESCRIPTION
This PR adds a possible solution to #118 . It uses the resolveDirectory to check PREFIX/share/oorb for the gnuplot scripts -if- OORB_GNUPLOT_SCRIPTS_DIR is not defined.

Similarly, resolveDirectory has been copied to planetary_data.f90 (because Base_class.f90 is not included there, and presumably you don't want to do so) and is used there to check the same directory for the BC430 files if OORB_DATA is not defined. It adds prefix.h as an include because the PREFIX is stored there.

Let me know if you're not happy with this and I'll see if I can adjust things.