### PR TITLE
mass_estimation_march: code cleanups and option to specify resolution

### DIFF
--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -2235,48 +2235,44 @@ CONTAINS
   ! https://doi.org/10.1016/j.icarus.2017.06.028
   ! Author: LS
   SUBROUTINE massEstimation_march(storb_arr, orb_arr, HG_arr, dyn_model, integrator, integration_step, &
-       perturbers, asteroid_perturbers, mass, out_fname)
+       perturbers, asteroid_perturbers, mass, out_fname, resolution)
     IMPLICIT NONE
     TYPE (StochasticOrbit), DIMENSION(:), INTENT(inout) :: storb_arr
-    TYPE (Orbit), DIMENSION(:), INTENT(inout) :: orb_arr
-    CHARACTER(len=FNAME_LEN), INTENT(in):: &
-         out_fname
-    TYPE (Orbit), DIMENSION(:,:), POINTER :: &
-         orb_arr2 => NULL()
-    TYPE (Time) :: t, t_prop
-    TYPE (File) :: march_out_file, res_file
-    INTEGER, DIMENSION(:), ALLOCATABLE :: nobs_arr
-    LOGICAL, DIMENSION(:,:), POINTER :: obs_masks
-    REAL(bp), DIMENSION(:,:), POINTER :: stdev_arr_measur, residuals
-    REAL(bp), DIMENSION(:,:), ALLOCATABLE :: chi2_arr
-    REAL(bp), INTENT(in), DIMENSION(:,:) :: HG_arr
-    REAL(bp), DIMENSION(6) :: perturber_elems, rms6, elements
-    REAL(bp), DIMENSION(1,8) :: additional_perturber
-    REAL(bp), DIMENSION(2) :: chi2_arr2
-    REAL(bp), DIMENSION(:), ALLOCATABLE :: marching_masses, chi2_sum_arr
-    REAL(bp) :: density, albedo, const, rough_estimate, lower_mass_bound, &
-         upper_mass_bound, chi_sum, integration_step, mass, avgstdev, &
-         rms1, rms2, best_chi, chi_perturber
-    LOGICAL, DIMENSION(10) :: &
-         perturbers
-    LOGICAL :: print_data, with_simplex, asteroid_perturbers
-    LOGICAL, DIMENSION(6) :: obs_masks2, obs_masks_true
-    INTEGER :: k, i, j,l,m, nobs
-    INTEGER :: outliertot
-    INTEGER, DIMENSION(6) :: n0
-    CHARACTER(len=DYN_MODEL_LEN) :: &
-         dyn_model                                                 !! Dynamical model.
-    CHARACTER(len=INTEGRATOR_LEN) :: &
-         integrator
-    REAL(bp), DIMENSION(:,:), ALLOCATABLE :: residuals_, observed_coords, &
+    TYPE (Orbit), DIMENSION(:), INTENT(inout)           :: orb_arr
+    CHARACTER(len=FNAME_LEN), INTENT(in)                :: out_fname
+    INTEGER, INTENT(INOUT)                              :: resolution
+    REAL(bp), INTENT(in), DIMENSION(:,:)                :: HG_arr
+
+    TYPE (Orbit), DIMENSION(:,:), POINTER               :: orb_arr2 => NULL()
+    TYPE (Time)                                         :: t, t_prop
+    TYPE (File)                                         :: march_out_file, res_file
+    INTEGER, DIMENSION(:), ALLOCATABLE                  :: nobs_arr
+    LOGICAL, DIMENSION(:,:), POINTER                    :: obs_masks
+    REAL(bp), DIMENSION(:,:), POINTER                   :: stdev_arr_measur, residuals
+    REAL(bp), DIMENSION(:,:), ALLOCATABLE               :: chi2_arr
+    REAL(bp), DIMENSION(6)                              :: perturber_elems, rms6, elements
+    REAL(bp), DIMENSION(1,8)                            :: additional_perturber
+    REAL(bp), DIMENSION(2)                              :: chi2_arr2
+    REAL(bp), DIMENSION(:), ALLOCATABLE                 :: marching_masses, chi2_sum_arr
+    REAL(bp)                                            :: density, albedo, const, &
+         rough_estimate, lower_mass_bound, upper_mass_bound, chi_sum, integration_step, &
+         mass, avgstdev, rms1, rms2, best_chi, chi_perturber, step
+    LOGICAL, DIMENSION(10)                              :: perturbers
+    LOGICAL                                             :: print_data, asteroid_perturbers
+    LOGICAL, DIMENSION(6)                               :: obs_masks2, obs_masks_true
+    INTEGER                                             :: k, i, j, l, m, nobs, outliertot
+    INTEGER, DIMENSION(6)                               :: n0
+    CHARACTER(len=DYN_MODEL_LEN)                        :: dyn_model
+    CHARACTER(len=INTEGRATOR_LEN)                       :: integrator
+    REAL(bp), DIMENSION(:,:), ALLOCATABLE               :: residuals_, observed_coords, &
          computed_coords, elements_arr, stdev, mean
-    TYPE (CartesianCoordinates), DIMENSION(:), POINTER :: &
+    TYPE (CartesianCoordinates), DIMENSION(:), POINTER  :: &
          obsy_ccoords => NULL()
-    TYPE (SphericalCoordinates), DIMENSION(:), POINTER :: &
+    TYPE (SphericalCoordinates), DIMENSION(:), POINTER  :: &
          observed_scoords => NULL(), &
          computed_scoords => NULL()
-    TYPE (Observations) :: obss
-    TYPE (SparseArray) :: resids
+    TYPE (Observations)                                 :: obss
+    TYPE (SparseArray)                                  :: resids
 
     CALL NEW(march_out_file, TRIM(out_fname))
     CALL OPEN(march_out_file)
@@ -2292,39 +2288,35 @@ CONTAINS
             perturbers=perturbers, asteroid_perturbers=asteroid_perturbers, integrator=integrator, &
             integration_step=integration_step)
     END DO
+    IF (resolution == 0) THEN
+      resolution = 300 ! Default value if resolution is not given.
+    END IF
+
     perturber_elems(:) = getElements(orb_arr(1), "cartesian", "equatorial")
 
     ! Rough mass estimate to sample in approximately right range:
     density = 2.5_bp ! g/cm3
-    density = density * 1.0e12_bp / kg_solar ! solar masses / km3
     albedo = 0.15_bp
-    const = 391222381.5_bp * pi * density / (albedo*SQRT(albedo))
+    const = 391222381.5_bp * pi * density * (1.0e12_bp / kg_solar) / (albedo*SQRT(albedo))
     rough_estimate = const*10**(-0.6_bp*HG_arr(1,1))
     WRITE(getUnit(march_out_file), *) "# Rough mass estimate for march:", rough_estimate
-    lower_mass_bound = 0.2_bp * rough_estimate
+    lower_mass_bound = 0.1_bp * rough_estimate
     upper_mass_bound = 10.0_bp * rough_estimate
 
-    j = 50000
-    ALLOCATE(marching_masses(j))
+    ALLOCATE(marching_masses(resolution))
+    ALLOCATE(chi2_arr(resolution,size(orb_arr)))
+    ALLOCATE(chi2_sum_arr(resolution))
+
+    ! Generates an array of evenly spaced masses.
+    step = 1.0_bp/resolution * upper_mass_bound
     marching_masses(1) = lower_mass_bound
-    j = 50000
 
-    DO i=2, j
-       marching_masses(i) = marching_masses(i-1) + rough_estimate*0.02_bp
-
-       IF (marching_masses(i) > upper_mass_bound) THEN
-          k = i
-          WRITE(stderr, *) "Testing with ", k, " masses."
-          EXIT
-       END IF
-       !       ELSE IF (i == j) THEN
-       !          WRITE(stderr, * ) "Too many masses!!!!"
-       !          STOP
-       !       END IF
+    DO i=1,resolution
+      mass = lower_mass_bound + (i-1) * step
+      marching_masses(i) = mass
     END DO
-    ALLOCATE(chi2_arr(k,size(orb_arr)))
-    ALLOCATE(chi2_sum_arr(k))
-    DO i=1, k
+
+    DO i=1, resolution
        CALL setParameters(orb_arr(1), mass=marching_masses(i))
        chi2_arr(i,:) = getChi2(storb_arr, orb_arr, resids)
        chi2_sum_arr(i) = SUM(chi2_arr(i,:))

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -346,7 +346,7 @@ PROGRAM oorb
        vomcmc_norb_iter, vomcmc_ntrial_iter, vomcmc_nmap, &
        year, year0, year1, &
        loc, nfile, &
-       itrial, nperturber, ntrial
+       itrial, nperturber, ntrial, resolution
   LOGICAL, DIMENSION(:,:), POINTER :: &
        obs_masks => NULL()
   LOGICAL, DIMENSION(:), POINTER :: &
@@ -9607,7 +9607,8 @@ PROGRAM oorb
   ! "marching" mass estimation algorithm
 
   CASE ("mass_estimation_march")
-     out_fname = TRIM(get_cl_option("--output=","placeholder"))
+     out_fname  = TRIM(get_cl_option("--output=","march_output"))
+     resolution = get_cl_option("--resolution=",0)
 
      ALLOCATE(orb_arr(size(storb_arr_in)))
      CALL readConfigurationFile(conf_file, &
@@ -9676,7 +9677,7 @@ PROGRAM oorb
      END DO
      WRITE(stdout, *) "Starting mass estimation..."
      CALL massEstimation_march(storb_arr_in, orb_arr, HG_arr_in, dyn_model, integrator, &
-                               integration_step, perturbers, asteroid_perturbers, mass, out_fname)
+                               integration_step, perturbers, asteroid_perturbers, mass, out_fname,resolution)
      WRITE(stdout, *) "Mass estimation is done."
      WRITE(stdout, *) "Best mass is ", mass
      DO i = 1, SIZE(storb_arr_in)


### PR DESCRIPTION
This PR cleans up the mass_estimation_march code a little bit and adds a new (optional) command line option to specify the resolution of the run (that is to say, the number of masses that are tested). I will document it on the wiki once the PR is merged.

No changes outside the marching algorithm.