### PR TITLE
Correctly include tags in compute-version.sh

### DIFF
--- a/build-tools/compute-version.sh
+++ b/build-tools/compute-version.sh
@@ -38,7 +38,7 @@ DEFAULT_VERSION=v1.0.2
 
 compute_version() {
 	# See if we have any tags defined
-	GD=$(git describe --always --long --dirty --match 'v[0-9]*' 2>/dev/null)
+	GD=$(git describe --always --long --dirty --match 'v[0-9]*' --tags 2>/dev/null)
 	if [[ ! -z $GD ]]; then
 		IFS=- read TAG COUNT HASH DIRTY <<< "$GD"
 


### PR DESCRIPTION
While getting ready for a new official release (woo!) I noticed that there appears to be a bug in compute-version.sh where, according to comments, the intended behavior is

`If the current commit has an annotated tag attached to it, the version is simply the tag with the leading 'v' removed.`

However, this doesn't currently occur in practise as the tags are not checked at all. This quick PR seems to fix that (tagging -heh-  @mjuric - does this make sense?)
I suppose that this has simply never come up before because we've never actually had any tags before.