### PR TITLE
Random walk ranging: correct the dimensions of the rms vector

### DIFF
--- a/classes/StochasticOrbit_class.f90
+++ b/classes/StochasticOrbit_class.f90
@@ -6612,8 +6612,8 @@ CONTAINS
     REAL(bp), DIMENSION(6,6):: information_matrix_elem, &
          jacobian_matrix
     REAL(bp), DIMENSION(6) :: elements, rans, state, state_, &
-         proposal_density
-    REAL(bp), DIMENSION(3) :: pos, rms
+         proposal_density, rms
+    REAL(bp), DIMENSION(3) :: pos
     REAL(bp) :: chi2, ran, t1, t2, obs_coord, jac_sph_inv, &
          jac_sph_inv_, chi2_, chi2min, avalue, a, q, e, dchi2, chi2min_prm
     INTEGER, DIMENSION(:,:), POINTER :: obs_pair_arr => NULL()

--- a/modules/utilities.f90
+++ b/modules/utilities.f90
@@ -1610,7 +1610,7 @@ CONTAINS
     IF (PRESENT(frmt)) THEN
        WRITE(str,TRIM(frmt),iostat=err) r
     ELSE
-       WRITE(str,'(F0.8)',iostat=err) r
+       WRITE(str,*,iostat=err) r
     END IF
     IF (err /= 0) THEN
        error = .TRUE.
@@ -1656,7 +1656,7 @@ CONTAINS
     IF (PRESENT(frmt)) THEN
        WRITE(str,TRIM(frmt),iostat=err) r
     ELSE
-       WRITE(str,'(F0.16)',iostat=err) r
+       WRITE(str,*,iostat=err) r
     END IF
     IF (err /= 0) THEN
        error = .TRUE.


### PR DESCRIPTION
This partially fixes #87 by correctly initializing a rms vector as 6-dimensional.

As noted in my comment on the relevant issue, the crash only occurs with debug builds because the rms values are not actually used anywhere (as far as I can tell) so the compiler is presumably optimizing the line out and thus avoiding the crash. As such, it might make more sense to just remove the rms computation entirely but, for now, I chose to keep it there just in case it's there for a reason..

With this commit, Grigori's test case still does crash for me with a debug build later - in makeResidualStamps, specifically, with the relevant error being `(io / makeResidualStamps) TRACE BACK (80)` which points to the culprit being the toString function (which is called with the float value `0.30000001192092896`, with which it fails with iostat code 5006, which means `LIBERROR_FORMAT`)