### PR TITLE
MCMC fixes and updates

### DIFF
--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -2335,12 +2335,6 @@ CONTAINS
 
     ALLOCATE(nobs_arr(size(orb_arr)))
 
-    DO i=1, size(orb_arr)
-       orb_arr(i) = getNominalOrbit(storb_arr(i))
-       CALL setParameters(orb_arr(i), dyn_model=dyn_model, &
-            perturbers=perturbers, asteroid_perturbers=asteroid_perturbers, integrator=integrator, &
-            integration_step=integration_step)
-    END DO
     IF (resolution == 0) THEN
       resolution = 300 ! Default value if resolution is not given.
     END IF
@@ -2373,7 +2367,7 @@ CONTAINS
        CALL setParameters(orb_arr(1), mass=marching_masses(i))
        chi2_arr(i,:) = getChi2(storb_arr, orb_arr, resids)
        chi2_sum_arr(i) = SUM(chi2_arr(i,:))
-       WRITE(getUnit(march_out_file), *) marching_masses(i), chi2_arr(i,:), i, k
+       WRITE(getUnit(march_out_file), *) marching_masses(i), chi2_arr(i,:), chi2_sum_arr(i), i
     END DO
     mass = marching_masses(MINLOC(chi2_sum_arr,dim=1))
     WRITE(getUnit(march_out_file), *) "# Best mass: ", mass

--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -1711,7 +1711,7 @@ CONTAINS
        WRITE(stderr, * ) "----------------------------"
        covariance2(i,:,:) = getCovarianceMatrix(storb_arr(i), "cartesian", "equatorial")
        ! Merge covariance matrices into one
-       cov_matrix(1+(i-1)*6:6+(i-1)*6,1+(i-1)*6:6+(i-1)*6) = covariance(:,:)
+       cov_matrix(1+(i-1)*6:6+(i-1)*6,1+(i-1)*6:6+(i-1)*6) = covariance(:,:) * lambda_arr(1,1)
 
        ! populate perturber array for integrations
        IF (i <= nperturber) THEN
@@ -1728,7 +1728,7 @@ CONTAINS
     ! Add masses into cov matrix
     IF (.NOT. ASSOCIATED(input_cov_matrix)) THEN
       DO i=1, nperturber
-         cov_matrix(6*nstorb+i, 6*nstorb+i) = proposal_density_masses(i)*1e-12_bp
+         cov_matrix(6*nstorb+i, 6*nstorb+i) = proposal_density_masses(i)*1e-19_bp
       END DO
     END IF
 

--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -1592,7 +1592,7 @@ CONTAINS
          ran, &
          tmp, tt, &
          last_accepted_chi2
-    REAL(kind=16) :: pdv, a_r, expo, last_accepted_expo
+    REAL(hp) :: pdv, a_r, expo, last_accepted_expo
     TYPE (Time) :: t
     INTEGER, DIMENSION(:), ALLOCATABLE :: &
          indx_arr, &
@@ -1795,7 +1795,7 @@ CONTAINS
        rchi2_arr = chi2_arr / (nobs_arr - nstorb*6 - nperturber)
        !       pdv = EXP(-0.5_bp*SUM(chi2_arr)/(SUM(nobs_arr)-nstorb*6-nperturber-1))
        !       expo = -0.5_bp*(SUM(chi2_arr)-SUM(nobs_arr)-nstorb*6-nperturber)
-       expo = -0.5_bp*SUM(chi2_arr)
+       expo = -0.5_hp*SUM(chi2_arr)
        !expo = -0.5_bp*(SUM(chi2_arr)/(2*SUM(nobs_arr)-nstorb*6-nperturber))
        pdv = EXP(expo)
 
@@ -1816,12 +1816,12 @@ CONTAINS
           first = .FALSE.
        ELSE
           chi2_compared = .FALSE.
-          a_r = 1.0_bp
+          a_r = 1.0_hp
 
           IF (expo - last_accepted_expo > 1000) THEN
-             a_r = 1.0_bp
+             a_r = 1.0_hp
           ELSE IF  (expo - last_accepted_expo < -1000) THEN
-             a_r = 0.0_bp
+             a_r = 0.0_hp
           ELSE
              a_r = EXP(expo - last_accepted_expo)
           END IF
@@ -1835,13 +1835,13 @@ CONTAINS
           ! Values of infinity may also occur but they are handled by the next
           ! if clause.
           IF (a_r /= a_r) THEN 
-             a_r = 0.0_bp
+             a_r = 0.0_hp
           END IF
           WRITE(stderr, *) "a_r:", a_r
 
-          IF (a_r > 1.0_bp) THEN
+          IF (a_r > 1.0_hp) THEN
              WRITE(stderr, *) "BETTER!"
-             a_r = 1.0_bp
+             a_r = 1.0_hp
              accept = .TRUE.
           ELSE
              CALL randomNumber(ran)

--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -1816,6 +1816,8 @@ CONTAINS
           first = .FALSE.
        ELSE
           chi2_compared = .FALSE.
+          a_r = 1.0_bp
+
           IF (expo - last_accepted_expo > 1000) THEN
              a_r = 1.0_bp
           ELSE IF  (expo - last_accepted_expo < -1000) THEN
@@ -1823,12 +1825,12 @@ CONTAINS
           ELSE
              a_r = EXP(expo - last_accepted_expo)
           END IF
-          IF (iorb > -1) THEN ! Experimental acceptance probability. Overrides the above
-             a_r = 1.0_bp
-             DO j=1, nstorb
-                a_r = a_r * EXP(-0.5_bp*(chi2_arr(j) - last_accepted_chi2_arr(j)))
-             END DO
-          END IF
+
+          ! Alternative acceptance probability. See Siltala & Granvik (2021a)
+          !DO j=1, nstorb
+          !   a_r = a_r * EXP(-0.5_bp*(chi2_arr(j) - last_accepted_chi2_arr(j)))
+          !END DO
+
           WRITE(stderr, *) "a_r:", a_r
 
 

--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -1831,12 +1831,14 @@ CONTAINS
           !   a_r = a_r * EXP(-0.5_bp*(chi2_arr(j) - last_accepted_chi2_arr(j)))
           !END DO
 
+          ! This catches NaN values (can occur with very bad proposals)
+          ! Values of infinity may also occur but they are handled by the next
+          ! if clause.
+          IF (a_r /= a_r) THEN 
+             a_r = 0.0_bp
+          END IF
           WRITE(stderr, *) "a_r:", a_r
 
-
-          IF (info_verb >= 3) THEN
-             WRITE(stderr, *) "a_r:", a_r
-          END IF
           IF (a_r > 1.0_bp) THEN
              WRITE(stderr, *) "BETTER!"
              a_r = 1.0_bp

--- a/classes/PhysicalParameters_class.f90
+++ b/classes/PhysicalParameters_class.f90
@@ -1868,7 +1868,7 @@ CONTAINS
           END IF
           ! Outlier detection happens here. We also need to get
           ! updated chi2 values after.
-          IF (MOD(iorb,500) == 0) THEN
+          IF (((iorb /= 0) .AND. (MOD(iorb,500) == 0 )) .OR. iorb == 15) THEN
              CALL outlierDetection(storb_arr)
              IF (ASSOCIATED(resids%vectors(1)%elements)) THEN
                 DEALLOCATE(resids%vectors)

--- a/main/io.f90
+++ b/main/io.f90
@@ -571,7 +571,8 @@ CONTAINS
        eph_lt_correction, eph_dt_since_last_obs, eph_obsy_code, &
        eph_date, &
        masked_obs, write_residuals, &
-       sor_rhofname)
+       sor_rhofname, &
+       massest_mcmc_lock, massest_mcmc_adaptation, massest_mcmc_norb)
 
     IMPLICIT NONE
     TYPE (File), INTENT(in) :: &
@@ -594,7 +595,8 @@ CONTAINS
          sor_2point_method_sw, &
          observation_format_out, &
          orbit_format_out, &
-         planetary_ephemeris_fname
+         planetary_ephemeris_fname, &
+         massest_mcmc_adaptation
     REAL(bp), DIMENSION(6,2), INTENT(inout), OPTIONAL :: &
          vov_scaling, &
          vomcmc_scaling
@@ -662,7 +664,8 @@ CONTAINS
          smplx_niter, &
          os_norb, &
          os_ntrial, &
-         os_sampling_type
+         os_sampling_type, &
+         massest_mcmc_norb
     LOGICAL, DIMENSION(:), POINTER, OPTIONAL :: &
          eph_lt_correction, &
          perturbers
@@ -688,6 +691,7 @@ CONTAINS
          smplx_force, &
          generat_gaussian_deviates, &
          write_residuals, &
+         massest_mcmc_lock, &
          pp_H_estimation
 
     CHARACTER(len=256) :: line, par_id, par_val
@@ -1637,6 +1641,31 @@ CONTAINS
              CALL toInt(TRIM(par_val), os_sampling_type, error)
           END IF
 
+          ! MCMC MASS ESTIMATION PARAMETERS:
+       CASE ("massest.mcmc.adaptation")
+          IF (PRESENT(massest_mcmc_adaptation)) THEN
+             massest_mcmc_adaptation = TRIM(par_val)
+          END IF
+       CASE ("massest.mcmc.norb")
+          IF (PRESENT(massest_mcmc_norb)) THEN
+             CALL toInt(TRIM(par_val), massest_mcmc_norb, error)
+          END IF
+       CASE ("massest.mcmc.lock")
+          IF (PRESENT(massest_mcmc_lock)) THEN
+             IF (.NOT.error) THEN
+                SELECT CASE (ADJUSTL(par_val))
+                CASE ("t", "T")
+                   massest_mcmc_lock = .TRUE.
+                CASE ("f", "F")
+                   massest_mcmc_lock = .FALSE.
+                CASE default
+                   error = .TRUE.
+                   CALL errorMessage("io / readConfigurationFile", &
+                        "Cannot understand logical value: " // &
+                        TRIM(ADJUSTL(par_val)) // ".", 1)
+                END SELECT
+             END IF
+          END IF
 
           ! PHYSICAL PARAMETERS:
        CASE ("pp.H_estimation")

--- a/main/oorb.conf
+++ b/main/oorb.conf
@@ -423,6 +423,24 @@ os.ntrial: 10000
 # with the previous accepted orbit.
 os.sampling_type: 1
 
+# MCMC MASS ESTIMATION
+
+# Specifies the adaptation flavor used for MCMC mass estimation.
+# Options are none, AM, ASWAM, RAM or GASWAM (default).
+# Respectively, these correspond to no adaptation whatsoever,
+# the AM algorithm from our 2017 paper and the ASWAM, RAM and GASWAM
+# algorithms described in the 2020 paper. GASWAM is recommended.
+# [ none | am | aswam | ram | gaswam ]
+massest.mcmc.adaptation: gaswam
+
+# Specifies the number of accepted MCMC proposals that are desired.
+massest.mcmc.norb: 50000
+
+# Locks the mass(es) to their initial values, leaving only orbits
+# as free parameters in MCMC. Do not enable unless you know what
+# you are doing.
+# [ T | F ]
+massest.mcmc.lock: F
 
 # PHYSICAL PARAMETERS
 

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -9489,11 +9489,11 @@ PROGRAM oorb
      IF (ASSOCIATED(mcmc_orb_arr)) THEN 
         another_temp_arr(8) = -1.0_bp
         ! Let's store the old accepted solutions here. We'll need them at least for adaptation.
-        DO i=1, size(mcmc_orb_arr,dim=2)
-          DO j=1, size(mcmc_orb_arr,dim=1)
+        DO i=1, size(mcmc_orb_arr,dim=1)
+          DO j=1, size(mcmc_orb_arr,dim=2)
             CALL getParameters(mcmc_orb_arr(i,j),mass=another_temp_arr(7))
             another_temp_arr(1:6) = getElements(mcmc_orb_arr(i,j), "cartesian", frame)
-            accepted_solutions(8*(j-1)+1*8:j,j) = another_temp_arr
+            accepted_solutions(8*(i-1)+1:8*i,j) = another_temp_arr
           END DO 
         END DO
      END IF 

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -9551,7 +9551,6 @@ PROGRAM oorb
      ALLOCATE (orb_arr(SIZE(storb_arr_in)))
      DO i = 1, SIZE(storb_arr_in)
        IF (ASSOCIATED(mcmc_orb_arr)) THEN
-          adaptation = "ram"
           orb_arr(i) = mcmc_orb_arr(i,size(mcmc_orb_arr,dim=2))
           mass = 1.0_bp
           CALL getParameters(orb_arr(i),mass=proposal_density_masses(i))

--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -381,7 +381,8 @@ PROGRAM oorb
        dchi2_rejection, &
        write_residuals, &
        asteroid_perturbers, &
-       delayed_rejection
+       delayed_rejection, &
+       mass_lock
   ! Defaults:
   error = .FALSE.
   task = " "
@@ -9477,6 +9478,8 @@ PROGRAM oorb
      ! This is used to enable Mira's delayed rejection algorithm. May not currently work as expected
      delayed_rejection = get_cl_option("--delayed-rejection", .false.)
      nperturber = get_cl_option("--nperturber=", 1)
+     mass_lock = get_cl_option("--lock", .false.)
+
      ALLOCATE (proposal_density_masses(SIZE(storb_arr_in)))
      proposal_density_masses = -1.0_bp
      norb = get_cl_option("--norb=", 50000) 
@@ -9585,7 +9588,7 @@ PROGRAM oorb
      CALL massEstimation_MCMC(storb_arr_in, orb_arr, proposal_density_masses, norb, iorb_init=iorb, itrial_init=itrial, &
                      estimated_masses=estimated_masses, accepted_solutions=accepted_solutions, nominal_arr=nominal_arr, &
                      adaptation=adaptation, delayed_rejection=delayed_rejection,out_fname=out_fname, &
-                     input_cov_matrix=mcmc_cov_matrix)
+                     input_cov_matrix=mcmc_cov_matrix, mass_lock=mass_lock)
      WRITE (stderr, *) "Mass estimation is done."
 
      DO i = 1, nperturber


### PR DESCRIPTION
Contains various fixes and tweaks mainly regarding resuming previous MCMC mass estimation runs and computing the acceptance criterion a_r (the algorithm itself is unchanged)

Also a commit is added to no longer force the RAM adaptation scheme when resuming a previous run - other schemes crashed that case before, but no longer (of course it can still used if the user so chooses, and it's probably a good idea to do so).

Routines for masking and unmasking Gaia observations are included, to be used with MCMC mass estimation to avoid local minima.
Relativistic correction based on F. Mignard's code for Gaia DR2 data is implemented.
MCMC mass estimation options are added in oorb.conf.
Then there are some other random odds and ends.