### PR TITLE
Add additional options to compile with 'conda' provided gfortran

### DIFF
--- a/configure
+++ b/configure
@@ -201,6 +201,12 @@ elif [[ $1 == gfortran ]] ; then
     echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
     echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_GFORTRAN)' >> $include_file
 
+elif [[ $1 == conda ]] ; then
+    echo "FC = ${FC}" > $include_file
+    echo "FCOPTIONS = $FFLAGS $LDFLAGS -cpp ""$ADDOPTS" >> $include_file
+    echo 'FC_INC = $(FC_INC_GFORTRAN)' >> $include_file
+    echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
+    echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_GFORTRAN)' >> $include_file
 else
 
     echo Erroneous compiler: $1

--- a/data/JPL_ephemeris/Makefile
+++ b/data/JPL_ephemeris/Makefile
@@ -101,11 +101,11 @@ test : $(TESTER) $(EPH_BIN) testpo.$(EPH_TYPE)
 
 # Compile ascii-to-binary converter:
 $(CONVERTER): $(CONV_SRC) ../../lib/liboorb.a
-	$(FC) -o $(CONVERTER) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a $(ADDLIBS) 
+	$(FC) -o $(CONVERTER) $(FCOPTIONS) $(FC_INC)../../build $(CONV_SRC) ../../lib/liboorb.a $(ADDLIBS) 
 
 # Compile tester:
 $(TESTER): $(TEST_SRC) ../../lib/liboorb.a
-	$(FC) -o $(TESTER) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a $(ADDLIBS) 
+	$(FC) -o $(TESTER) $(FCOPTIONS) $(FC_INC)../../build $(TESTER_SRC) ../../lib/liboorb.a $(ADDLIBS) 
 
 # Download individual ephemeris files (via a temp file, so that partial downloads aren't
 # seen as successful by make


### PR DESCRIPTION
The additions to the configure file add the flags needed to let someone compile using gfortran and lapack provided by conda otherwise these versions - particularly the lapack library - aren't found correctly. 
The additions to the data/JPL_ephemeris/Makefile are similar, and use the same options set in the configure step.
To use these options, someone would then build using
'./configure conda opt --with-pyoorb' (for example). 

If 'gfortran' is used for the configure step, the conda versions will not be used. 
I note that I had some issue with lapack library version finding when trying to install without conda and using the homebred-installed gfortran .. it seemed like the home-brew and system lapack were having some issues. Using 'conda', I was able to install the ephemeris files correctly.