### PR TITLE
Implement support for the flang compiler

### DIFF
--- a/configure
+++ b/configure
@@ -207,6 +207,19 @@ elif [[ $1 == conda ]] ; then
     echo 'FC_INC = $(FC_INC_GFORTRAN)' >> $include_file
     echo 'FC_SHARED = $(FC_SHARED_GFORTRAN)' >> $include_file
     echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_GFORTRAN)' >> $include_file
+
+elif [[ $1 == flang ]] ; then
+
+    echo 'FC = $(FC_FLANG)' > $include_file
+    if [[ $2 == opt ]] ; then
+	echo 'FCOPTIONS = $(FCOPTIONS_OPT_FLANG)'"$ADDOPTS" >> $include_file
+    else
+	echo 'FCOPTIONS = $(FCOPTIONS_DEB_FLANG)'"$ADDOPTS" >> $include_file
+    fi
+    echo 'FC_INC = $(FC_INC_FLANG)' >> $include_file
+    echo 'FC_SHARED = $(FC_SHARED_FLANG)' >> $include_file
+    echo 'F2PY_FCOMPILER = $(F2PY_FCOMPILER_FLANG)' >> $include_file
+
 else
 
     echo Erroneous compiler: $1

--- a/main/ephemeris_linking.f90
+++ b/main/ephemeris_linking.f90
@@ -283,6 +283,7 @@ PROGRAM ephemeris_linking
        j_min, &
        k_min
   INTEGER :: &
+       getpid, system, &
        task, &
        err, &
        i, &

--- a/main/orbit_linking.f90
+++ b/main/orbit_linking.f90
@@ -194,6 +194,7 @@ PROGRAM orbit_linking
   INTEGER, DIMENSION(6) :: box_nrs
   INTEGER, DIMENSION(3) :: i4arr
   INTEGER :: &
+       getpid, system, &
        filter_start, &
        filter_stop, &
        ifilter, &

--- a/make.config
+++ b/make.config
@@ -109,6 +109,14 @@ FC_INC_GFORTRAN           = -I
 FC_SHARED_GFORTRAN        = -shared
 F2PY_FCOMPILER_GFORTRAN   = --fcompiler=gnu95
 
+# flang: 
+FC_FLANG                  = flang
+FCOPTIONS_OPT_FLANG       = -O2 -fPIC -std=f95 -fall-intrinsics -cpp -flto -pipe -funroll-loops -fstack-arrays -fno-protect-parens
+FCOPTIONS_DEB_FLANG       = -g -O0 -fPIC -fbounds-check -pedantic -Wall -std=f95 -fall-intrinsics -cpp -pipe
+FC_INC_FLANG              = -I
+FC_SHARED_FLANG           = -shared
+F2PY_FCOMPILER_FLANG      = --fcompiler=flang
+
 # Absoft: 
 FC_ABSOFT            = f90
 FCOPTIONS_OPT_ABSOFT = -en -O2 -cpu:p7 -lU77 -YDEALLOC=ALL


### PR DESCRIPTION
This PR adds support for compiling oorb with the "new", shiny open-source `flang` compiler which is part of the LLVM project.
LLVM 12+ is required - when I tried with 11 some time ago, oorb did not build, but as of version 12 it does.
As with other compilers. to use flang you just call `configure` with e.g. `./configure flang opt` and it will work.

Based on my (limited) testing, the performance delta between gfortran 11.1.0 and flang 12 is less than 1% (in gfortran's favor) so they are pretty much equivalent in that sense.

One change to the code was necessary to get things to work - `getpid` and `system` needed to be explicitly declared in orbit_linking and ephemeris_linking. It should not break anything - at least gfortran seems to still work fine.
This is documented in e.g. https://support.huaweicloud.com/intl/en-us/ug-bisheng-kunpengdevps/ug-bisheng-kunpengdevps.pdf section 7.5.2.