### PR TITLE
Use Python to look up extension suffix, not python3-config which is nonstandard

### DIFF
--- a/build-tools/get-python-extension-suffix.sh
+++ b/build-tools/get-python-extension-suffix.sh
@@ -8,5 +8,5 @@ PYVER=$($PYTHON -c 'import sys; print(sys.version_info[0])')
 if [[ $PYVER == 2 ]]; then
 	echo ".so"
 elif [[ $PYVER == 3 ]]; then
-	python3-config --extension-suffix
+	$PYTHON -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))'
 fi


### PR DESCRIPTION
python3-config is a script which is included in `python3-dev` when you install on Ubuntu, but it's not at all standard or part of the Python standard library. That script just runs `sysconfig.get_config_var("EXT_SUFFIX")`.

But since it's a script installed by the OS package manager, it's not controllable with virtualenvironments or with conda. So on systems with multiple Python versions (eg with environments) it will give the wrong answer, which breaks the build. This fixes that.