### PR TITLE
Misc fixes

### DIFF
--- a/main/oorb.f90
+++ b/main/oorb.f90
@@ -7479,6 +7479,7 @@ PROGRAM oorb
               CALL NULLIFY(orb_lt_corr_arr(j))
               CALL NULLIFY(ccoord)
               CALL NULLIFY(obsy_ccoord)
+              CALL NULLIFY(t)
 
 
            END DO

--- a/modules/sort.f90
+++ b/modules/sort.f90
@@ -34,7 +34,7 @@ MODULE sort
   USE utilities
 
   IMPLICIT NONE
-  INTEGER, PARAMETER :: NN = 15, NSTACK = 100
+  INTEGER, PARAMETER :: NN = 15, NSTACK = 200
 
   INTERFACE insertionSort
      MODULE PROCEDURE insertionSort_i8


### PR DESCRIPTION
The ephemeris task was missing a call to nullify the `t` object which led to crashes when trying to generate ephemerides for multiple objects without covariance matrices. 
The one-liner here fixes that problem.

Also, a separate commit is added to increase the nstack parameter to fix #159 