### PR TITLE
Publish wheels to PyPI

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -55,6 +55,10 @@ jobs:
         env:
           CIBW_BUILD: "${{ matrix.pyversion }}*"
           CIBW_ARCHS: aarch64
+          # Numpy doesn't provide musl aarch64 wheels, and building
+          # Numpy from scratch in that scenario takes a _very_ long
+          # time (6+ hours, it times out). So, skip those.
+          CIBW_SKIP: "*-musllinux*"
         with:
            output-dir: wheelhouse
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,9 +1,6 @@
 name: Build and upload release to PyPI
 
 on:
-  push:
-    branches:
-      - master
   release:
     types:
       - published

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,9 +1,12 @@
-name: Build Python Wheels
+name: Build and upload release to PyPI
 
-# TODO: Shrink this down to pushes to master, perhaps. During development, this
-# needs to run more often to work out bugs.
 on:
-  - push
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
 
 jobs:
   build_x86_wheels:
@@ -16,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.4
@@ -172,3 +177,46 @@ jobs:
             pip install --no-index --no-deps --find-links /tmp/artifacts/wheels pyoorb && \
             pip install --find-links /tmp/artifacts/wheels pyoorb && \
             python /tmp/oorb_latest/python/test.py"
+
+  build_sdist:
+    # Make a plain source distribution with nothing precompiled.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build SDist
+      run: pipx run build --sdist
+    - uses: actions/upload-artifact@v3
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  upload_all:
+    name: Upload release to PyPI
+    needs:
+      - build_sdist
+      - test_x86_wheels
+      - test_linux_aarch64_wheels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: sdist
+        path: ./sdist/
+    - uses: actions/download-artifact@v3
+      with:
+        name: x86_wheels
+        path: ./x86_wheels/
+    - uses: actions/download-artifact@v3
+      with:
+        name: aarch64_wheels
+        path: ./aarch64_wheels/
+    - name: Combine artifacts
+      run: |
+        mkdir dist
+        mv sdist/* dist
+        mv x86_wheels/* dist
+        mv aarch64_wheels/* dist
+    - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Add pushes of built wheels to PyPI. This is triggered by publish actions of github releases.

This hasn't been tested end-to-end, really, since it is written to be triggered only by publishing a github release. I _think_ that should communicate the right Git tag information through so that the version is set properly, but it's hard to be sure of that until we actually attempt a github release.

I would suggest verifying the workflow by publishing a prerelease version. The version string needs to comply with [PEP-440](https://peps.python.org/pep-0440/) so it could be something like `1.3.0a1` to indicate "alpha 1", and `1.3.0a2` if that doesn't work, and so on, incrementing the counter until it actually works; then it could be `1.3.0`.

Take care that the git tag must be prefixed by `v`, so these would be tagged as `v1.3.0a1`, `v1.3.0a2`, and so on. The `VERSION` file does _not_ get that `v` prefix though.