### PR TITLE
Support setting additional compiler flags

### DIFF
--- a/configure
+++ b/configure
@@ -73,6 +73,10 @@ do
 			shift;
 		;;
 
+		--with-compiler-options=*)
+			ADDOPTS="$ADDOPTS ${key#*=}"
+	 		shift;
+		;;
 		*)
 		POSITIONAL+=("$1")
 		shift;


### PR DESCRIPTION
Support calling `./configure --with-compiler-options`, for example `./configure gfortran --with-compiler-options=-march=native`.  

This is useful to me because `-march=native` improves performance dramatically, at the cost of making the built binary only good for the architecture it was built on. In some informal experiments on an Intel Cascade Lake CPU, this makes propagations 30-40% faster. 