### PR TITLE
Build and publish Python 3.12 wheels

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        pyversion: [cp38, cp39, cp310, cp311]
+        pyversion: [cp38, cp39, cp310, cp311, cp312]
         os: [macos-latest, ubuntu-latest]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyversion: [cp38, cp39, cp310, cp311]
+        pyversion: [cp38, cp39, cp310, cp311, cp312]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.12 was released on October 2, two days ago. This fixes #175.