### PR TITLE
Print out correlations even when covariances are small

### DIFF
--- a/classes/Observation_class.f90
+++ b/classes/Observation_class.f90
@@ -1266,12 +1266,8 @@ CONTAINS
           DEALLOCATE(records, stat=err)
           RETURN
        END IF
-       IF (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)) > EPSILON(correlation)) THEN
-          correlation = this%covariance(2,3) / &
-               (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)))
-       ELSE
-          correlation = 0.0_bp
-       END IF
+       correlation = this%covariance(2,3) / &
+            (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)))
        ! Optical:
        IF (SQRT(this%covariance(2,2))/rad_asec > 0.01_bp .AND. &
             SQRT(this%covariance(3,3))/rad_asec > 0.01_bp) THEN
@@ -1435,12 +1431,8 @@ CONTAINS
        IF (day < 10.0_bp) THEN
           day_str = "0" // TRIM(day_str)
        END IF
-       IF (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)) > EPSILON(correlation)) THEN
-          correlation = this%covariance(2,3) / &
-               (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)))
-       ELSE
-          correlation = 0.0_bp
-       END IF
+       correlation = this%covariance(2,3) / &
+            (SQRT(this%covariance(2,2))*SQRT(this%covariance(3,3)))
        ! Optical:
        IF (SQRT(this%covariance(2,2))/rad_asec > 0.01_bp .AND. &
             SQRT(this%covariance(3,3))/rad_asec > 0.01_bp) THEN


### PR DESCRIPTION
As pointed out by email, the routines for printing out mpc2 and mpc3 observation files print a correlation of zero if the covariances are small, as can be the case for Gaia data. This removes that check as it has evidently caused confusion and, at least on my end, the correlations that are printed out with this commit pretty much match those reported in gfpr files.